### PR TITLE
Refs #11 Added tool to update version number in project tree

### DIFF
--- a/bin/yawg
+++ b/bin/yawg
@@ -12,6 +12,7 @@ _scriptDir=$(dirname $0)
 _scriptName=$(basename $0)
 _yawgHome=$(cd $_scriptDir/..; pwd)
 
+source ${_yawgHome}/lib/bash/yawg-utils.sh
 source ${_yawgHome}/conf/yawg-defaults.conf
 
 

--- a/devtools/bin/build-sync-version
+++ b/devtools/bin/build-sync-version
@@ -1,0 +1,306 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+#
+#
+# Updates the project version in all pom.xml files to match the
+# version defined in "conf/yawg-defaults.conf".
+#
+###########################################################################
+
+_scriptName=$0
+_scriptDir=$(dirname $0)
+_yawgHome=$(cd $_scriptDir/../..; pwd)
+
+source ${_yawgHome}/lib/bash/yawg-utils.sh
+source ${_yawgHome}/conf/yawg-defaults.conf
+
+
+
+
+
+PRODUCT_NAME="Yawg"
+TOOL_NAME="Version updater"
+COPYRIGHT_HEADER="Copyright (c) 2016 Jorge Nunes, All Rights Reserved."
+PRODUCT_HEADER="${PRODUCT_NAME} ${YAWG_VERSION} - ${TOOL_NAME}"
+
+DEFAULT_NEW_BUILD_NUMBER=SNAPSHOT
+
+_newBuildNumber=${DEFAULT_NEW_BUILD_NUMBER}
+_newVersion=
+_isQuiet=false
+_masterConfFile=${_yawgHome}/conf/yawg-defaults.conf
+_xsltprocTool=xsltproc
+
+
+
+
+
+#######################################################################
+#
+# The main script.
+#
+#######################################################################
+
+function main () {
+
+    processCliArgs "$@"
+
+    yawgCheckForTools \
+        "${_xsltprocTool}"
+    
+    updateVersion
+}
+
+
+
+
+
+###########################################################################
+#
+# Processes the command line options.
+#
+###########################################################################
+
+function processCliArgs () {
+
+    for option in "$@" ; do
+        case $option in
+            --quiet )
+                _isQuiet=true
+                ;;
+            --build-number=* )
+                _newBuildNumber=$(expr "$option" : '--build-number=\(.*\)')
+                ;;
+            --help )
+                displayHelp
+                exit 0
+                ;;
+            --*=* )
+                option=$(expr $option : '\(--.*\)=.*')
+                yawgError "$option : unknown option. Use --help for details."
+                ;;
+            * )
+                yawgError "$option : unknown option. Use --help for details."
+                ;;
+        esac
+    done
+
+    if [ -z "$_newBuildNumber" ] ; then
+        yawgError "Missing mandatory --build-number option. Use --help for details."
+    fi
+}
+
+
+
+
+
+###########################################################################
+#
+# Displays an help messages describing the configuration options.
+#
+###########################################################################
+
+function displayHelp () {
+
+    cat <<EOF
+
+${PRODUCT_HEADER}
+${COPYRIGHT_HEADER}
+
+Updates the version number in source files.
+
+Available options:
+
+--build-number=BUILD_NUMBER
+    Version number sufix. The product version is obtained by
+    concatenating the main version with the provided build number. If
+    not specified it will default to
+    ${DEFAULT_NEW_BUILD_NUMBER}. Special value NONE means no build
+    number is to be appended to the version number.
+
+--quiet
+    Do not show any logging messages.
+
+--help
+    Prints this help text.
+
+EOF
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function updateVersion () {
+
+    myLog "${PRODUCT_HEADER}"
+    myLog "    Build number : ${_newBuildNumber}"
+
+    updateBuildNumberInConfigFile
+
+    local newVersion=$(source ${_masterConfFile} ; echo ${YAWG_VERSION})
+    myLog "Syncing version to ${newVersion}"
+
+    updateVersionInPomFiles
+
+    myLog "Done updating build number to ${_newBuildNumber}"
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function updateBuildNumberInConfigFile () {
+
+    local confFile=${_masterConfFile}
+    local tmpConfFile=${confFile}.new
+    local newBuildNumber=${_newBuildNumber}
+
+    if [ "${newBuildNumber}" == NONE ] ; then
+        newBuildNumber=""
+    fi
+
+    sed "s/^YAWG_BUILD_NUMBER=.*/YAWG_BUILD_NUMBER=${newBuildNumber}/" \
+        < ${confFile} \
+        > ${tmpConfFile}
+
+    mv ${tmpConfFile} ${confFile}
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function updateVersionInPomFiles () {
+
+    local newVersion=$(source ${_masterConfFile} ; echo ${YAWG_VERSION})
+
+    myLog "Updating POM files..."
+
+    local pomBase=${_yawgHome}/modules
+    local pomFileList="
+        ${pomBase}/pom.xml
+        ${pomBase}/*/pom.xml
+"
+
+    for pomFile in ${pomFileList} ; do
+        myLog "    $(getRelativePath ${pomFile} ${pomBase})"
+        updateVersionInOnePomFile ${newVersion} ${pomFile}
+    done
+}
+
+
+
+
+
+###########################################################################
+#
+# 
+#
+###########################################################################
+
+function updateVersionInOnePomFile () {
+
+    local newVersion=$1
+    local pomFile=$2
+
+    local newPomVersion=${newVersion}
+    local newParentVersion=${newVersion}
+    local newPomFile=${pomFile}.new
+    local xsltFile=${_scriptDir}/../lib/xslt/update-pom-version.xsl
+
+    ${_xsltprocTool} \
+        --stringparam NEW_POM_VERSION "${newPomVersion}" \
+        --stringparam NEW_PARENT_VERSION "${newParentVersion}" \
+        --output ${newPomFile} \
+        ${xsltFile} \
+        ${pomFile}
+
+    local xsltprocStatus=$?
+
+    if [ ${xsltprocStatus} -eq 0 ] ; then
+        mv ${newPomFile} ${pomFile}
+    else
+        rm -f ${newPomFile}
+    fi
+}
+
+
+
+
+
+###########################################################################
+#
+# 
+#
+###########################################################################
+
+function myLog () {
+
+    if [ ${_isQuiet} != true ] ; then
+        yawgLog "$@"
+    else
+        : # Show no logging.
+    fi
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+function getRelativePath () {
+
+    local path=$1
+    local basePath=$2
+
+    python -c "import os.path; print os.path.relpath('${path}', '${basePath}')"
+}
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+
+main "$@"
+
+
+
+
+
+#######################################################################
+#
+# 
+#
+#######################################################################
+

--- a/devtools/lib/xslt/update-pom-version.xsl
+++ b/devtools/lib/xslt/update-pom-version.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+
+XSLT for replacing the artifact version and parent version in a POM file.
+-->
+
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:t="http://maven.apache.org/POM/4.0.0">
+
+  <!-- These parameters must be set by the tool running the XSLT
+       transformation. -->
+  <xsl:param name="NEW_POM_VERSION"/>
+  <xsl:param name="NEW_PARENT_VERSION"/>
+
+  <xsl:output method="xml" encoding="UTF-8" />
+  
+  <!-- This is an identity template. It copies everything that does
+       not match another template -->
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <!-- Replace the project version with the value of the
+       NEW_POM_VERSION parameter. -->
+  <xsl:template match="/t:project/t:version/text()"><xsl:value-of select="$NEW_POM_VERSION"/></xsl:template>
+
+  <!-- Replace the project parent version with the value of the
+       NEW_PARENT_VERSION parameter. -->
+  <xsl:template match="/t:project/t:parent/t:version/text()">
+    <xsl:choose>
+      <xsl:when test="$NEW_PARENT_VERSION!=''"><xsl:value-of select="$NEW_PARENT_VERSION"/></xsl:when>
+      <xsl:otherwise><xsl:value-of select="."/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+    
+</xsl:stylesheet>

--- a/lib/bash/yawg-utils.sh
+++ b/lib/bash/yawg-utils.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+###########################################################################
+#
+# Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+#
+#
+# Utility functions. This script is not meant to be executed by
+# itself. Instead it is tipically sourced from within other scripts
+# using the Bash "source" operator.
+#
+#########################################################################
+
+
+
+
+
+###########################################################################
+#
+# Displays a message to stderr and exits the process.
+#
+# Arguments:
+#
+# 1. The message to be displayed.
+#
+###########################################################################
+
+function yawgError () {
+
+    echo "ERROR" $1 >&2
+    exit 1
+}
+
+
+
+
+
+###########################################################################
+#
+# Displays a message to stdout prefixed with the current time.
+#
+# Arguments:
+#
+# 1. The message to be displayed.
+#
+###########################################################################
+
+function yawgLog () {
+
+    echo $(date "+%Y-%m-%d %H:%M:%S") "$@"
+}
+
+
+
+
+
+###########################################################################
+#
+# Checks if a set of required tools is available. If any is missing
+# then an error message is output and the current process is
+# terminated.
+#
+# Arguments:
+#
+# 1. Tools to look for in the PATH or by path.
+#
+###########################################################################
+
+function yawgCheckForTools () {
+
+    local toolList="$@"
+
+    for tool in ${toolList} ; do
+        if type $tool > /dev/null 2>&1 ; then
+            : # We found the tool. All is ok
+        else
+            teaError "Missing \"${tool}\" tool. Please install this tool."
+        fi
+    done
+}
+

--- a/lib/jars/00README.txt
+++ b/lib/jars/00README.txt
@@ -1,5 +1,5 @@
 This directory will receive all the JARs required for running the Yawg
 tools.
 
-NOTE: This file is not to be in the release tarball.
+NOTE: This file is not to be included in the release tarball.
 

--- a/modules/cli/pom.xml
+++ b/modules/cli/pom.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2015 Jorge Nunes, All Rights Reserved.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -160,4 +154,3 @@ Copyright (c) 2015 Jorge Nunes, All Rights Reserved.
 
 
 </project>
-

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2015 Jorge Nunes, All Rights Reserved.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -107,4 +101,3 @@ Copyright (c) 2015 Jorge Nunes, All Rights Reserved.
 
 
 </project>
-

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2015-2016 Jorge Nunes, All Rights Reserved.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
@@ -321,4 +315,3 @@ Copyright (c) 2015-2016 Jorge Nunes, All Rights Reserved.
 
 
 </project>
-

--- a/modules/testutils/pom.xml
+++ b/modules/testutils/pom.xml
@@ -1,16 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 
 Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
 
 -->
-
-<project
-   xmlns="http://maven.apache.org/POM/4.0.0"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -56,4 +50,3 @@ Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
 
 
 </project>
-


### PR DESCRIPTION
Added 'devtools/bin/build-sync-version' for updating the software
version number in all required files. This tool is intended for use
only in the development environment.

This tool has two main purposes:

* Simplify the developers life when th version number changes - Only
  one file will need to be manually modified (conf/tea-core.conf).

* During the generation of a release bundle allow to use a unique
  build number as part of the version.