### PR TITLE
Added support for an assets directory

### DIFF
--- a/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCli.java
+++ b/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCli.java
@@ -120,12 +120,15 @@ public final class BakerCli
         Path targetDir = cliOptions.getPath(BakerCliOptions.TARGET_DIR);
         Path templatesDir =
                 cliOptions.getPath(BakerCliOptions.TEMPLATES_DIR, null);
+        Path assetsDir =
+                cliOptions.getPath(BakerCliOptions.ASSETS_DIR, null);
 
         BakerConf conf =
                 new BakerConf.Builder()
                 .setSourceDir(sourceDir)
                 .setTargetDir(targetDir)
                 .setTemplatesDir(templatesDir)
+                .setAssetsDir(assetsDir)
                 .build();
         Baker baker = new Baker(conf);
 

--- a/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCliOptions.java
+++ b/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCliOptions.java
@@ -24,13 +24,20 @@ public final class BakerCliOptions
     extends Object {
 
 
+    public static final CliOption ASSETS_DIR =
+        new CliOption.Builder()
+        .setLongName("assets")
+        .setArgName("PATH")
+        .setDescription("path of assets directory")
+        .build();
+
     public static final CliOption HELP =
         new CliOption.Builder()
         .setLongName("help")
         .setDescription("show this help text and exit")
         .setShortName("h")
         .build();
- 
+
     public static final CliOption SOURCE_DIR =
         new CliOption.Builder()
         .setLongName("source")
@@ -79,6 +86,7 @@ public final class BakerCliOptions
 
     static {
         CliOption[] allOptions = {
+            ASSETS_DIR,
             HELP,
             SOURCE_DIR,
             TARGET_DIR,

--- a/modules/core/src/main/java/com/varmateo/yawg/BakerConf.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/BakerConf.java
@@ -18,6 +18,7 @@ public final class BakerConf
     extends Object {
 
 
+    public final Path assetsDir;
     public final Path sourceDir;
     public final Path targetDir;
     public final Path templatesDir;
@@ -28,6 +29,7 @@ public final class BakerConf
      */
     private BakerConf(final Builder builder) {
 
+        this.assetsDir = builder._assetsDir;
         this.sourceDir = builder._sourceDir;
         this.targetDir = builder._targetDir;
         this.templatesDir = builder._templatesDir;
@@ -41,6 +43,7 @@ public final class BakerConf
         extends Object {
 
 
+        private Path _assetsDir = null;
         private Path _sourceDir = null;
         private Path _targetDir = null;
         private Path _templatesDir = null;
@@ -52,6 +55,16 @@ public final class BakerConf
         public Builder() {
 
             // Nothing to do.
+        }
+
+
+        /**
+         *
+         */
+        public Builder setAssetsDir(final Path assetsDir) {
+
+            _assetsDir = assetsDir;
+            return this;
         }
 
 


### PR DESCRIPTION
The assets directory is specified on the command line with the
--assets option.

When an assets directory is specified, its contents are copied without
changes to the target directory.