### PR TITLE
Refs#45 Added a baker for HTML source documents

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -54,6 +54,12 @@ Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
       <version>${freemaker.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>${jsoup.version}</version>
+    </dependency>
+
   </dependencies>
 
 

--- a/modules/core/src/main/java/com/varmateo/yawg/YawgDomain.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/YawgDomain.java
@@ -16,6 +16,7 @@ import com.varmateo.yawg.ItemBaker;
 import com.varmateo.yawg.BakerConf;
 import com.varmateo.yawg.asciidoctor.AsciidoctorBaker;
 import com.varmateo.yawg.freemarker.FreemarkerTemplateService;
+import com.varmateo.yawg.html.HtmlBaker;
 import com.varmateo.yawg.logging.Log;
 import com.varmateo.yawg.logging.LogFactory;
 import com.varmateo.yawg.util.Holder;
@@ -39,11 +40,14 @@ import com.varmateo.yawg.util.Holder;
     private final Holder<ItemBaker> _fileBaker =
             Holder.of(this::newFileBaker);
 
-    private final Holder<Log> _log =
-            Holder.of(this::newLog);
-
     private final Holder<PageTemplateService> _fmTemplateService =
             Holder.of(this::newFreemarkerTemplateService);
+
+    private final Holder<ItemBaker> _htmlBaker =
+            Holder.of(this::newHtmlBaker);
+
+    private final Holder<Log> _log =
+            Holder.of(this::newLog);
 
 
     /**
@@ -111,7 +115,10 @@ import com.varmateo.yawg.util.Holder;
 
         Log log = _log.get();
         Path sourceRootDir = _conf.sourceDir;
-        Collection<ItemBaker> bakers = Arrays.asList(_asciidocBaker.get());
+        Collection<ItemBaker> bakers =
+                Arrays.asList(
+                        _asciidocBaker.get(),
+                        _htmlBaker.get());
         ItemBaker defaultBaker = _copyBaker.get();
         ItemBaker result =
                 new FileBaker(log, sourceRootDir, bakers, defaultBaker);
@@ -128,6 +135,17 @@ import com.varmateo.yawg.util.Holder;
         Path templatesDir = _conf.templatesDir;
         PageTemplateService result =
                 new FreemarkerTemplateService(templatesDir);
+
+        return result;
+    }
+
+
+    /**
+     *
+     */
+    private ItemBaker newHtmlBaker() {
+
+        ItemBaker result = new HtmlBaker();
 
         return result;
     }

--- a/modules/core/src/main/java/com/varmateo/yawg/html/HtmlBaker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/html/HtmlBaker.java
@@ -1,0 +1,233 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+ *
+ **************************************************************************/
+
+package com.varmateo.yawg.html;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.varmateo.yawg.ItemBaker;
+import com.varmateo.yawg.YawgException;
+import com.varmateo.yawg.PageTemplate;
+import com.varmateo.yawg.PageTemplateDataModel;
+
+
+/**
+ * An <code>ItemBaker</code> that transforms HTML files into other
+ * HTML files.
+ */
+public final class HtmlBaker
+        extends Object
+        implements ItemBaker {
+
+
+    private static final String NAME = "html";
+
+    private static final Pattern RE_ADOC = Pattern.compile(".*\\.html$");
+
+    private static final String TARGET_EXTENSION = ".html";
+
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
+
+    /**
+     * 
+     */
+    public HtmlBaker() {
+
+        // Nothing to do.
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getShortName() {
+
+        return NAME;
+    }
+
+
+    /**
+     * Checks if the given file name has one of the known extensions.
+     *
+     * <p>The following extensions will be allowed:</p>
+     *
+     * <ul>
+     *   <li>.adoc</li>
+     * </ul>
+     *
+     * @return True if the given file name has one of the allowed
+     * extensions.
+     */
+    @Override
+    public boolean isBakeable(final Path path) {
+
+        String basename = path.getFileName().toString();
+        boolean result = RE_ADOC.matcher(basename).matches();
+
+        return result;
+    }
+
+
+    /**
+     * Converts the given text file in Asciidoc format into an HTML
+     * file.
+     *
+     * <p>The target directory must already exist. Otherwise an
+     * exception will be thrown.</p>
+     *
+     * @param sourcePath The file to be baked.
+     *
+     * @param template Used for generating the target document. If no
+     * template is provided, then the default AsciidoctorJ document
+     * generator will be used.
+     *
+     * @param targetDir The directory where the source file will be
+     * copied to.
+     *
+     * @exception YawgException Thrown if the copying failed for
+     * whatever reason.
+     */
+    @Override
+    public void bake(
+            final Path sourcePath,
+            final Optional<PageTemplate> template,
+            final Path targetDir)
+            throws YawgException {
+
+        try {
+            doBake(sourcePath, template, targetDir);
+        } catch ( IOException e ) {
+            YawgException.raise(
+                    e,
+                    "Failed {0} on {1} - {2} - {3}",
+                    NAME,
+                    sourcePath,
+                    e.getClass().getSimpleName(),
+                    e.getMessage());
+        }
+    }
+
+
+    /**
+     *
+     */
+    private void doBake(
+            final Path sourcePath,
+            final Optional<PageTemplate> template,
+            final Path targetDir)
+            throws IOException {
+
+        Path targetPath = getTargetPath(sourcePath, targetDir);
+
+        if ( template.isPresent() ) {
+            doBakeWithTemplate(sourcePath, template.get(), targetPath);
+        } else {
+            doBakeWithoutTemplate(sourcePath, targetPath);
+        }
+    }
+
+
+    /**
+     *
+     */
+    private Path getTargetPath(
+            final Path sourcePath,
+            final Path targetDir) {
+
+        String sourceBasename = sourcePath.getFileName().toString();
+        int extensionIndex = sourceBasename.lastIndexOf(".");
+        String sourceBasenameNoExtension =
+                (extensionIndex>-1)
+                ? sourceBasename.substring(0, extensionIndex)
+                : sourceBasename;
+        String targetBasename = sourceBasenameNoExtension + TARGET_EXTENSION;
+        Path targetPath = targetDir.resolve(targetBasename);
+
+        return targetPath;
+    }
+
+
+    /**
+     * Baking without a template just copies the source HTML file to
+     * the target location.
+     */
+    private void doBakeWithoutTemplate(
+            final Path sourcePath,
+            final Path targetPath)
+            throws IOException {
+
+        Files.copy(
+                sourcePath,
+                targetPath,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+
+    /**
+     *
+     */
+    private void doBakeWithTemplate(
+            final Path sourcePath,
+            final PageTemplate template,
+            final Path targetPath)
+            throws IOException {
+
+        PageTemplateDataModel dataModel = buildDataModel(sourcePath);
+
+        try ( Writer writer = Files.newBufferedWriter(targetPath, UTF8) ) {
+                template.process(dataModel, writer);
+        }
+    }
+
+
+    /**
+     *
+     */
+    private PageTemplateDataModel buildDataModel(final Path sourcePath)
+            throws IOException {
+
+        Optional<Document> document =
+                Optional.of(Jsoup.parse(sourcePath.toFile(), null));
+        String body =
+                document
+                .map(doc -> doc.getElementsByTag("body"))
+                .flatMap(elems -> Optional.ofNullable(elems.first()))
+                .map(Element::html)
+                .orElse("");
+        String title =
+                document
+                .map(doc -> doc.getElementsByTag("title"))
+                .flatMap(elems -> Optional.ofNullable(elems.first()))
+                .map(Element::text)
+                .orElse((String)null);
+
+        PageTemplateDataModel result =
+                new PageTemplateDataModel.Builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+
+        return result;
+    }
+
+
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -31,6 +31,7 @@ Copyright (c) 2015-2016 Jorge Nunes, All Rights Reserved.
     <junit.version>4.11</junit.version>
     <commons-cli.version>1.2</commons-cli.version>
     <freemaker.version>2.3.24-incubating</freemaker.version>
+    <jsoup.version>1.8.3</jsoup.version>
     <maven-assembly-plugin.version>2.5.3</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>2.16</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>2.6.1</maven-clean-plugin.version>


### PR DESCRIPTION
The HTML baker uses the literal contents of the <body> tag in the source
document as the body passed to the template.

The document title is extracted from the <title> document, it is
exists.