### PR TITLE
Refs #43 Added support for specifying files to ignore per directory

### DIFF
--- a/modules/core/src/main/java/com/varmateo/yawg/DirBaker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/DirBaker.java
@@ -94,7 +94,7 @@ import com.varmateo.yawg.logging.LogWithUtils;
         List<Path> entries =
                 doIoAction(
                         "list directory",
-                        ()-> getDirEntries(sourceDir));
+                        ()-> getDirEntries(sourceDir, dirBakerConf));
 
         List<Path> filePathList =
                 entries.stream()
@@ -158,16 +158,41 @@ import com.varmateo.yawg.logging.LogWithUtils;
     /**
      *
      */
-    private List<Path> getDirEntries(final Path dir)
+    private List<Path> getDirEntries(
+            final Path dir,
+            final DirBakerConf dirBakerConf)
         throws IOException {
 
         List<Path> result = null;
 
         try ( Stream<Path> entries = Files.list(dir) ) {
-            result = entries.sorted().collect(Collectors.toList());
+            result =
+                    entries
+                    .filter(entry -> isEntryAcceptable(entry, dirBakerConf))
+                    .sorted()
+                    .collect(Collectors.toList());
         }
 
         return result;
+    }
+
+
+    /**
+     *
+     */
+    private boolean isEntryAcceptable(
+            final Path entry,
+            final DirBakerConf dirBakerConf) {
+
+        String basename = entry.getFileName().toString();
+        boolean isToIgnore =
+                dirBakerConf.filesToIgnore.stream()
+                .filter(pattern -> pattern.matcher(basename).matches())
+                .findFirst()
+                .isPresent();
+        boolean isAcceptable = !isToIgnore;
+
+        return isAcceptable;
     }
 
 

--- a/modules/core/src/main/java/com/varmateo/yawg/DirBakerConf.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/DirBakerConf.java
@@ -6,7 +6,12 @@
 
 package com.varmateo.yawg;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.regex.Pattern;
+
+import com.varmateo.yawg.util.Lists;
 
 
 /**
@@ -17,7 +22,16 @@ import java.util.Optional;
         extends Object {
 
 
+    /**
+     * Name of template to use for the current directory and all
+     * sub-directories.
+     */
     public final Optional<String> templateName;
+
+    /**
+     * List of files to ignore.
+     */
+    public final Collection<Pattern> filesToIgnore;
 
 
     /**
@@ -26,6 +40,7 @@ import java.util.Optional;
     private DirBakerConf(final Builder builder) {
 
         this.templateName = builder._templateName;
+        this.filesToIgnore = Lists.readOnlyCopy(builder._filesToIgnore);
     }
 
 
@@ -43,9 +58,10 @@ import java.util.Optional;
 
         Builder builder = new Builder(that);
 
-        if ( templateName.isPresent() ) {
-            builder.setTemplateName(templateName.get());
+        if ( this.templateName.isPresent() ) {
+            builder.setTemplateName(this.templateName.get());
         }
+        builder.addFilesToIgnore(this.filesToIgnore);
 
         DirBakerConf result = builder.build();
 
@@ -61,6 +77,7 @@ import java.util.Optional;
 
 
         private Optional<String> _templateName = Optional.empty();
+        private Collection<Pattern> _filesToIgnore = new ArrayList<>();
 
 
         /**
@@ -78,6 +95,7 @@ import java.util.Optional;
         private Builder(final DirBakerConf defaults) {
 
             _templateName = defaults.templateName;
+            _filesToIgnore.addAll(defaults.filesToIgnore);
         }
 
 
@@ -87,6 +105,17 @@ import java.util.Optional;
         public Builder setTemplateName(final String templateName) {
 
             _templateName = Optional.of(templateName);
+
+            return this;
+        }
+
+
+        /**
+         *
+         */
+        public Builder addFilesToIgnore(final Collection<Pattern> fileNames) {
+
+            _filesToIgnore.addAll(fileNames);
 
             return this;
         }

--- a/modules/core/src/main/java/com/varmateo/yawg/util/Lists.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/util/Lists.java
@@ -1,0 +1,55 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+ *
+ **************************************************************************/
+
+package com.varmateo.yawg.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
+/**
+ * Utility functions for manipulating lists.
+ */
+public final class Lists
+    extends Object {
+
+
+    /**
+     *
+     */
+    private Lists() {
+    }
+
+
+    /**
+     *
+     */
+    public static <T> List<T> readOnlyCopy(
+            final Collection<T> inputCollection) {
+
+        List<T> copy = new ArrayList<T>(inputCollection);
+        List<T> result = Collections.unmodifiableList(copy);
+
+        return result;
+    }
+
+
+}
+
+
+
+
+
+/**************************************************************************
+ *
+ * 
+ *
+ **************************************************************************/
+


### PR DESCRIPTION
There is a new "ignore" configuration parameter recognized in the
'.yawg.yml' file per directory. Its value is expected to be a list of
strings represeting regexp patterns.

Files whose base names match any of the regexp patterns specified with
the "ignore" parameter will not be processed during the bake. Those
files will just be ignored.