### PR TITLE
Refs #44 Added support for specifying set of files to bake per directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#
+# List of glob patterns for files to be ignored by Git.
+#
+
 *~
 *.~??
 *.aux
@@ -6,3 +10,4 @@
 *.out
 *.pid
 target
+work

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -99,6 +99,12 @@ Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
               <value>${project.version}</value>
             </property>
 
+            <!-- Required by com.varmateo.testutils.TestUtils -->
+            <property>
+              <name>TestUtils.inputTestFilesDir</name>
+              <value>${basedir}/src/test/resources</value>
+            </property>
+
           </systemProperties>
 
         </configuration>

--- a/modules/core/src/main/java/com/varmateo/yawg/DirBaker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/DirBaker.java
@@ -111,7 +111,11 @@ import com.varmateo.yawg.logging.LogWithUtils;
                 .collect(Collectors.toList());
 
         if ( dirPathList.size() > 0 ) {
-            bakeChildDirectories(sourceDir, dirPathList, targetDir, dirBakerConf);
+            bakeChildDirectories(
+                    sourceDir,
+                    dirPathList,
+                    targetDir,
+                    dirBakerConf);
         }
     }
 
@@ -166,33 +170,15 @@ import com.varmateo.yawg.logging.LogWithUtils;
         List<Path> result = null;
 
         try ( Stream<Path> entries = Files.list(dir) ) {
+            DirEntryChecker checker = new DirEntryChecker(dirBakerConf);
             result =
                     entries
-                    .filter(entry -> isEntryAcceptable(entry, dirBakerConf))
+                    .filter(checker.asPathPredicate())
                     .sorted()
                     .collect(Collectors.toList());
         }
 
         return result;
-    }
-
-
-    /**
-     *
-     */
-    private boolean isEntryAcceptable(
-            final Path entry,
-            final DirBakerConf dirBakerConf) {
-
-        String basename = entry.getFileName().toString();
-        boolean isToIgnore =
-                dirBakerConf.filesToIgnore.stream()
-                .filter(pattern -> pattern.matcher(basename).matches())
-                .findFirst()
-                .isPresent();
-        boolean isAcceptable = !isToIgnore;
-
-        return isAcceptable;
     }
 
 

--- a/modules/core/src/main/java/com/varmateo/yawg/DirBakerConf.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/DirBakerConf.java
@@ -23,15 +23,20 @@ import com.varmateo.yawg.util.Lists;
 
 
     /**
-     * Name of template to use for the current directory and all
+     * Name of template to use when baking a directory and all its
      * sub-directories.
      */
     public final Optional<String> templateName;
 
     /**
-     * List of files to ignore.
+     * List of files to ignore when baking a directory.
      */
     public final Collection<Pattern> filesToIgnore;
+
+    /**
+     * Strict list of files to include when baking a directory.
+     */
+    public final Optional<Collection<Pattern>> filesToIncludeOnly;
 
 
     /**
@@ -39,8 +44,12 @@ import com.varmateo.yawg.util.Lists;
      */
     private DirBakerConf(final Builder builder) {
 
-        this.templateName = builder._templateName;
-        this.filesToIgnore = Lists.readOnlyCopy(builder._filesToIgnore);
+        this.templateName =
+                builder._templateName;
+        this.filesToIgnore =
+                Lists.readOnlyCopy(builder._filesToIgnore);
+        this.filesToIncludeOnly =
+                builder._filesToIncludeOnly.map(Lists::readOnlyCopy);
     }
 
 
@@ -62,6 +71,7 @@ import com.varmateo.yawg.util.Lists;
             builder.setTemplateName(this.templateName.get());
         }
         builder.addFilesToIgnore(this.filesToIgnore);
+        this.filesToIncludeOnly.ifPresent(builder::setFilesToIncludeOnly);
 
         DirBakerConf result = builder.build();
 
@@ -76,8 +86,12 @@ import com.varmateo.yawg.util.Lists;
             extends Object {
 
 
-        private Optional<String> _templateName = Optional.empty();
-        private Collection<Pattern> _filesToIgnore = new ArrayList<>();
+        private Optional<String> _templateName =
+                Optional.empty();
+        private Collection<Pattern> _filesToIgnore =
+                new ArrayList<>();
+        private Optional<Collection<Pattern>> _filesToIncludeOnly =
+                Optional.empty();
 
 
         /**
@@ -90,12 +104,14 @@ import com.varmateo.yawg.util.Lists;
 
 
         /**
-         *
+         * Prepares a Builder for performing a merge.
          */
         private Builder(final DirBakerConf defaults) {
 
             _templateName = defaults.templateName;
             _filesToIgnore.addAll(defaults.filesToIgnore);
+
+            // The _filesToIncludeOnly always start empty.
         }
 
 
@@ -116,6 +132,18 @@ import com.varmateo.yawg.util.Lists;
         public Builder addFilesToIgnore(final Collection<Pattern> fileNames) {
 
             _filesToIgnore.addAll(fileNames);
+
+            return this;
+        }
+
+
+        /**
+         *
+         */
+        public Builder setFilesToIncludeOnly(
+                final Collection<Pattern> fileNames) {
+
+            _filesToIncludeOnly = Optional.of(new ArrayList<>(fileNames));
 
             return this;
         }

--- a/modules/core/src/main/java/com/varmateo/yawg/DirEntryChecker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/DirEntryChecker.java
@@ -1,0 +1,114 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+ *
+ **************************************************************************/
+
+package com.varmateo.yawg;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import com.varmateo.yawg.DirBakerConf;
+
+
+/**
+ * Used for checking if a file should be used in a baking.
+ */
+/* package private */ final class DirEntryChecker
+        extends Object {
+
+
+    private final DirBakerConf _conf;
+    private final boolean _isIncludeOnly;
+
+
+    /**
+     *
+     */
+    public DirEntryChecker(final DirBakerConf conf) {
+
+        _conf = conf;
+        _isIncludeOnly = conf.filesToIncludeOnly.isPresent();
+    }
+
+
+    /**
+     *
+     */
+    public Predicate<Path> asPathPredicate() {
+
+        return this::testPath;
+    }
+
+
+    /**
+     *
+     */
+    public Predicate<String> asStringPredicate() {
+
+        return this::testString;
+    }
+
+
+    /**
+     *
+     */
+    private boolean testPath(final Path path) {
+
+        String basename = path.getFileName().toString();
+        boolean result = testString(basename);
+
+        return result;
+    }
+
+
+    /**
+     *
+     */
+    private boolean testString(final String name) {
+
+        boolean result =
+                _isIncludeOnly
+                ? testForIncludeOnly(name)
+                : !testForIgnore(name);
+
+        return result;
+    }
+
+
+    /**
+     *
+     */
+    private boolean testForIncludeOnly(final String name) {
+
+        boolean result =
+                _conf.filesToIncludeOnly
+                .map(
+                        collection ->
+                        collection.stream()
+                        .filter(pattern -> pattern.matcher(name).matches())
+                        .findFirst()
+                        .isPresent())
+                .orElse(false);
+
+        return result;
+    }
+
+
+    /**
+     *
+     */
+    private boolean testForIgnore(final String name) {
+
+        boolean result =
+                _conf.filesToIgnore.stream()
+                .filter(pattern -> pattern.matcher(name).matches())
+                .findFirst()
+                .isPresent();
+
+        return result;
+    }
+
+
+}

--- a/modules/core/src/main/java/com/varmateo/yawg/html/HtmlBaker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/html/HtmlBaker.java
@@ -85,8 +85,8 @@ public final class HtmlBaker
 
 
     /**
-     * Converts the given text file in Asciidoc format into an HTML
-     * file.
+     * Converts the given text file in HTML format into another HTML
+     * file processed through the template engine.
      *
      * <p>The target directory must already exist. Otherwise an
      * exception will be thrown.</p>
@@ -94,10 +94,10 @@ public final class HtmlBaker
      * @param sourcePath The file to be baked.
      *
      * @param template Used for generating the target document. If no
-     * template is provided, then the default AsciidoctorJ document
-     * generator will be used.
+     * template is provided, then the source document is just copied
+     * to the target directory.
      *
-     * @param targetDir The directory where the source file will be
+     * @param targetDir The directory where the baked file will be
      * copied to.
      *
      * @exception YawgException Thrown if the copying failed for

--- a/modules/core/src/main/java/com/varmateo/yawg/util/Exceptions.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/util/Exceptions.java
@@ -159,15 +159,9 @@ public final class Exceptions
     }
 
 
-
-
-
-/**************************************************************************
- *
- * 
- *
- **************************************************************************/
-
+    /**
+     *
+     */
     private static <T extends Exception> T
         newException(final Class<T>  exceptionClass,
                      final Throwable cause,
@@ -217,9 +211,6 @@ public final class Exceptions
     }
 
 
-
-
-
     /**
      * Builds a string with the stack trace of the given
      * exception. The string is obtained directly from
@@ -249,14 +240,3 @@ public final class Exceptions
 
 
 }
-
-
-
-
-
-/**************************************************************************
- *
- * 
- *
- **************************************************************************/
-

--- a/modules/core/src/main/java/com/varmateo/yawg/util/Lists.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/util/Lists.java
@@ -31,6 +31,22 @@ public final class Lists
     /**
      *
      */
+    public static <T,R> List<R> map(
+            final Collection<T> inputCollection,
+            final Function<T,R> function) {
+
+        List<R> mappedList =
+            inputCollection.stream()
+            .map(function)
+            .collect(Collectors.toList());
+
+        return mappedList;
+    }
+
+
+    /**
+     *
+     */
     public static <T> List<T> readOnlyCopy(
             final Collection<T> inputCollection) {
 
@@ -42,14 +58,3 @@ public final class Lists
 
 
 }
-
-
-
-
-
-/**************************************************************************
- *
- * 
- *
- **************************************************************************/
-

--- a/modules/core/src/test/java/com/varmateo/yawg/DirBakerConfDaoTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/DirBakerConfDaoTest.java
@@ -1,0 +1,313 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+ *
+ **************************************************************************/
+
+package com.varmateo.yawg;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.varmateo.testutils.TestUtils;
+import com.varmateo.yawg.DirBakerConfDao;
+import com.varmateo.yawg.util.Lists;
+
+
+/**
+ *
+ */
+public final class DirBakerConfDaoTest
+        extends Object {
+
+
+    private final DirBakerConf _emptyConf = new DirBakerConf.Builder().build();
+    private DirBakerConfDao _dao = null;
+
+
+    @Before
+    public void setUp() {
+
+        _dao = new DirBakerConfDao();
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void emptyConf()
+            throws IOException {
+
+        String confContents = "";
+        DirBakerConf actualConf = readFromString(confContents);
+        DirBakerConf expectedConf = _emptyConf;
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withTemplateParamOk()
+            throws IOException {
+
+        String templateName = "demo";
+        String confContents = ""
+                + "template: " + templateName;
+        DirBakerConf actualConf = readFromString(confContents);
+        DirBakerConf expectedConf =
+                new DirBakerConf.Builder()
+                .setTemplateName(templateName)
+                .build();
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withTemplateParamMissing() {
+
+        assertFalse(_emptyConf.templateName.isPresent());
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withTemplateParamFail()
+            throws IOException {
+
+        String confContents = ""
+                + "template: \n"
+                + "  - something: wrong"; 
+
+        TestUtils.assertThrows(
+                YawgException.class,
+                () -> readFromString(confContents));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreParamOk()
+            throws IOException {
+
+        String confContents = ""
+                + "ignore:\n"
+                + "  - one\n"
+                + "  - two\n";
+        DirBakerConf actualConf = readFromString(confContents);
+        DirBakerConf expectedConf =
+                new DirBakerConf.Builder()
+                .addFilesToIgnore(
+                        Arrays.asList(
+                                Pattern.compile("one"),
+                                Pattern.compile("two")))
+                .build();
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreParamMissing()
+            throws IOException {
+
+        assertEquals(0, _emptyConf.filesToIgnore.size());
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreParamFail()
+            throws IOException {
+
+        String confContents = ""
+                + "ignore: \n"
+                + "  - something: wrong"; 
+
+        TestUtils.assertThrows(
+                YawgException.class,
+                () -> readFromString(confContents));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreParamInvalidRegex()
+            throws IOException {
+
+        String confContents = ""
+                + "ignore: \n"
+                + "  - \"[\""; 
+
+        TestUtils.assertThrows(
+                YawgException.class,
+                () -> readFromString(confContents));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIncludeOnlyParamOk()
+            throws IOException {
+
+        String confContents = ""
+                + "includeOnly:\n"
+                + "  - one\n"
+                + "  - two\n";
+        DirBakerConf actualConf = readFromString(confContents);
+        DirBakerConf expectedConf =
+                new DirBakerConf.Builder()
+                .setFilesToIncludeOnly(
+                        Arrays.asList(
+                                Pattern.compile("one"),
+                                Pattern.compile("two")))
+                .build();
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIncludeOnlyParamMissing() {
+
+        assertFalse(_emptyConf.filesToIncludeOnly.isPresent());
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void loadFromFileOk() {
+
+        Path confFile =
+                TestUtils
+                .getInputsDir(DirBakerConfDao.class)
+                .resolve("dirWithYawgYml/.yawg.yml");
+        DirBakerConf actualConf = _dao.loadFromFile(confFile);
+        DirBakerConf expectedConf =
+                new DirBakerConf.Builder()
+                .setTemplateName("demo")
+                .build();
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void loadFromFileNoFile() {
+
+        Path noSuchPath = Paths.get("this/file/does/not/exist");
+
+        TestUtils.assertThrows(
+                YawgException.class,
+                () -> _dao.loadFromFile(noSuchPath));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void loadOk() {
+
+        Path sourceDir =
+                TestUtils
+                .getInputsDir(DirBakerConfDao.class)
+                .resolve("dirWithYawgYml");
+        DirBakerConf actualConf = _dao.load(sourceDir);
+        DirBakerConf expectedConf =
+                new DirBakerConf.Builder()
+                .setTemplateName("demo")
+                .build();
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void loadNoYawgYml() {
+
+        Path sourceDir =
+                TestUtils
+                .getInputsDir(DirBakerConfDao.class)
+                .resolve("dirWithNoYawgYml");
+        DirBakerConf actualConf = _dao.load(sourceDir);
+        DirBakerConf expectedConf = _emptyConf;
+
+        assertConfEquals(expectedConf, actualConf);
+    }
+
+
+    /**
+     *
+     */
+    private void assertConfEquals(
+            final DirBakerConf expectedConf,
+            final DirBakerConf actualConf) {
+
+        assertEquals(
+                expectedConf.templateName,
+                actualConf.templateName);
+        assertEquals(
+                Lists.map(expectedConf.filesToIgnore, Pattern::pattern),
+                Lists.map(actualConf.filesToIgnore, Pattern::pattern));
+        assertEquals(
+                expectedConf.filesToIncludeOnly.map(
+                        c -> Lists.map(c, Pattern::pattern)),
+                actualConf.filesToIncludeOnly.map(
+                        c -> Lists.map(c, Pattern::pattern)));
+    }
+
+
+    /**
+     *
+     */
+    private DirBakerConf readFromString(final String confContents)
+            throws IOException {
+
+        DirBakerConf result = _dao.read(new StringReader(confContents));
+
+        return result;
+    }
+
+
+}

--- a/modules/core/src/test/java/com/varmateo/yawg/DirEntryCheckerTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/DirEntryCheckerTest.java
@@ -1,0 +1,171 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
+ *
+ **************************************************************************/
+
+package com.varmateo.yawg;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import com.varmateo.yawg.DirBakerConf;
+import com.varmateo.yawg.DirEntryChecker;
+import com.varmateo.yawg.util.Lists;
+
+
+/**
+ *
+ */
+public final class DirEntryCheckerTest
+        extends Object {
+
+
+    /**
+     *
+     */
+    @Test
+    public void withEmptyConf() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+
+        assertTrue(checker.asStringPredicate().test("anything"));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreOne() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .addFilesToIgnore(
+                        Lists.map(Arrays.asList(".*\\.txt"), Pattern::compile))
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<String> predicate = checker.asStringPredicate();
+
+        assertTrue(predicate.test("something.adoc"));
+        assertFalse(predicate.test("something.txt"));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreTwo() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .addFilesToIgnore(
+                        Lists.map(
+                                Arrays.asList(".*\\.txt", ".*\\.puml"),
+                                Pattern::compile))
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<String> predicate = checker.asStringPredicate();
+
+        assertTrue(predicate.test("something.adoc"));
+        assertFalse(predicate.test("something.txt"));
+        assertFalse(predicate.test("something.puml"));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIncludeOnlyOne() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .setFilesToIncludeOnly(
+                        Lists.map(Arrays.asList(".*\\.adoc"), Pattern::compile))
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<String> predicate = checker.asStringPredicate();
+
+        assertTrue(predicate.test("something.adoc"));
+        assertFalse(predicate.test("something.txt"));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIncludeOnlyTwo() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .setFilesToIncludeOnly(
+                        Lists.map(
+                                Arrays.asList(".*\\.adoc", ".*\\.svg"),
+                                Pattern::compile))
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<String> predicate = checker.asStringPredicate();
+
+        assertTrue(predicate.test("something.adoc"));
+        assertTrue(predicate.test("something.svg"));
+        assertFalse(predicate.test("something.txt"));
+        assertFalse(predicate.test("something.puml"));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void withIgnoreAndInclude() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .addFilesToIgnore(
+                        Lists.map(Arrays.asList(".*\\.txt"), Pattern::compile))
+                .setFilesToIncludeOnly(
+                        Lists.map(Arrays.asList(".*\\.adoc"), Pattern::compile))
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<String> predicate = checker.asStringPredicate();
+
+        assertTrue(predicate.test("something.adoc"));
+        assertFalse(predicate.test("something.txt"));
+        assertFalse(predicate.test("something.svg"));
+    }
+
+
+    /**
+     *
+     */
+    @Test
+    public void pathWithIgnoreOne() {
+
+        DirBakerConf conf =
+                new DirBakerConf.Builder()
+                .addFilesToIgnore(
+                        Lists.map(Arrays.asList(".*\\.txt"), Pattern::compile))
+                .build();
+        DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<Path> predicate = checker.asPathPredicate();
+
+        assertTrue(predicate.test(Paths.get("something.adoc")));
+        assertFalse(predicate.test(Paths.get("something.adoc/else.txt")));
+        assertFalse(predicate.test(Paths.get("something.txt")));
+        assertTrue(predicate.test(Paths.get("something.txt/else.adoc")));
+    }
+
+
+}

--- a/modules/core/src/test/java/com/varmateo/yawg/YawgInfoTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/YawgInfoTest.java
@@ -9,12 +9,9 @@ package com.varmateo.yawg;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
+import com.varmateo.testutils.TestUtils;
+
 import com.varmateo.yawg.YawgInfo;
-
-import com.varmateo.yawg.util.Exceptions;
-
-
-
 
 
 /**
@@ -31,7 +28,7 @@ public final class YawgInfoTest
     public void checkVersion() {
 
         String expectedVersion = getYawgVersion();
-        String actualVersion   = YawgInfo.VERSION;
+        String actualVersion = YawgInfo.VERSION;
 
         assertEquals(expectedVersion, actualVersion);
     }
@@ -43,26 +40,10 @@ public final class YawgInfoTest
     private String getYawgVersion() {
 
         String key = YawgInfoTest.class.getSimpleName() + ".version";
-        String version = System.getProperty(key);
-
-        if ( version == null ) {
-            String msgFmt = "System property \"{0}\" is not defined";
-            Exceptions.raise(IllegalStateException.class, msgFmt, key);
-        }
+        String version = TestUtils.getSystemProperty(key);
 
         return version;
     }
 
 
 }
-
-
-
-
-
-/**************************************************************************
- *
- * 
- *
- **************************************************************************/
-

--- a/modules/core/src/test/resources/com/varmateo/yawg/DirBakerConfDao/dirWithNoYawgYml/00README.txt
+++ b/modules/core/src/test/resources/com/varmateo/yawg/DirBakerConfDao/dirWithNoYawgYml/00README.txt
@@ -1,0 +1,2 @@
+This directory does not contain a '.yawg.yml' file. Used in unit
+tests.

--- a/modules/core/src/test/resources/com/varmateo/yawg/DirBakerConfDao/dirWithYawgYml/.yawg.yml
+++ b/modules/core/src/test/resources/com/varmateo/yawg/DirBakerConfDao/dirWithYawgYml/.yawg.yml
@@ -1,0 +1,5 @@
+#
+# Correctly formed .yawg.yml file.
+#
+
+template: demo

--- a/modules/core/src/test/resources/com/varmateo/yawg/DirBakerConfDao/dirWithYawgYml/00README.txt
+++ b/modules/core/src/test/resources/com/varmateo/yawg/DirBakerConfDao/dirWithYawgYml/00README.txt
@@ -1,0 +1,1 @@
+This directory contains a valid '.yawg.yml' file. Used in unit tests.

--- a/modules/testutils/src/main/java/com/varmateo/testutils/TestUtils.java
+++ b/modules/testutils/src/main/java/com/varmateo/testutils/TestUtils.java
@@ -6,20 +6,16 @@
 
 package com.varmateo.testutils;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 
 import org.junit.Assert;
 
 
-
-
-
-/**************************************************************************
- *
+/**
  * Utility functions intended for use in unit tests.
- *
- **************************************************************************/
-
+ */
 public final class TestUtils
     extends Object {
 
@@ -27,53 +23,131 @@ public final class TestUtils
 
 
 
-/**************************************************************************
- *
- * No instances of this class are to be created.
- *
- **************************************************************************/
+    private static final String PROP_INPUTS_DIR_PREFIX =
+            TestUtils.class.getSimpleName() + ".inputTestFilesDir";
 
+
+    /**
+     * No instances of this class are to be created.
+     */
     private TestUtils() {
     }
 
 
+    /**
+     * Retrieves the value of a given system property. If the system
+     * property is not set, then it will blow up.
+     */
+    public static String getSystemProperty(final String key) {
+
+        String value = System.getProperty(key);
+
+        if ( value == null ) {
+            String msg =
+                    MessageFormat.format(
+                    "System property \"{0}\" is not defined",
+                    key);
+            throw new IllegalStateException(msg);
+        }
+
+        return value;
+    }
 
 
+    /**
+     * Retrieves the directory containing the test input files for the
+     * given testuite class.
+     *
+     * <p>By convention the path of directory with test input files is
+     * obtained in the following way:</p>
+     *
+     * <ul>
+     *
+     * <li>The prefix component is obtained from the value of the
+     * <code>TestUtils.inputTestFilesDir</code> system property. This
+     * is usually set to <code>${basedir}/test/resources</code> in the
+     * Maven project <code>pom.xml</code>.</li>
+     *
+     * <li>The remaining path components are obtained from the fully
+     * qualified class name by replacing "." with the path separator
+     * char.</li>
+     *
+     *</ul>
+     *
+     * @param testsuiteClass Class for which we will return in directory
+     * with input files for the corresponding testsuite.
+     */
+    public static Path getInputsDir(final Class<?> testsuiteClass) {
 
-/**************************************************************************
- *
- * Checks that the given task does throw the expected exception.
- *
- * <p>The task is executed. If it throws an exception of the given
- * type, then this method just returns the exception object.</p>
- *
- * <p>If the task throws no exception, then JUnits
- * <code>Assert.fail()</code> will be called, causing the JUnit test
- * invoking this method to fail</p>
- *
- * <p>If the task throws an exception of a type not compatible with
- * the given type, then an
- * <code>java.lang.IllegalStateException</code> will be thrown.
- *
- * @param <T> The type of exception the task is expected to throw.
- *
- * @param expectedExceptionClass The class of the exception the task
- * is expected to throw. This can be wither a checked or an unchecked
- * exception.
- *
- * @param task The runnable that will be excuted,
- *
- * @return The exception thrown during the execution of the given task.
- *
- * @throws IllegalStateException When the task throws an exception,
- * but it is of a type not compatible with
- * <code>expectedExceptionClass</code>.
- *
- **************************************************************************/
+        String inputsDirPrefix =
+                getSystemProperty(PROP_INPUTS_DIR_PREFIX);
+        String[] pathComponents =
+            testsuiteClass.getName().split("\\.");
+        Path inputsDirPath =
+            Paths.get(inputsDirPrefix, pathComponents);
 
-    public static <T extends Throwable> T
-        assertThrows(final Class<T> expectedExceptionClass,
-                     final TestTask task) {
+        return inputsDirPath;
+    }
+
+
+    /**
+     * Retrives the path for a test file related with the given
+     * testsuit class.
+     *
+     * <p>The <code>pathName</code> is assumed to be relative to the
+     * inputs directory for the given testsuit class. See <code>{@link
+     * #getInputsDir(Class)}</code> for a description on on how the
+     * inputs directory is obtained.
+     *
+     * @param testsuiteClass 
+     *
+     * @param pathName A path relative to the inputs directory for the
+     * given testsuite class.
+     *
+     * @return The path for the desired test file of the testsuite.
+     */
+    public static Path getPath(
+            final Class<?> testsuiteClass,
+            final String   pathName) {
+
+        Path inputsDir = getInputsDir(testsuiteClass);
+        Path inputPath = inputsDir.resolve(pathName);
+
+        return inputPath;
+    }
+
+
+    /**
+     * Checks that the given task does throw the expected exception.
+     *
+     * <p>The task is executed. If it throws an exception of the given
+     * type, then this method just returns the exception object.</p>
+     *
+     * <p>If the task throws no exception, then JUnits
+     * <code>Assert.fail()</code> will be called, causing the JUnit test
+     * invoking this method to fail</p>
+     *
+     * <p>If the task throws an exception of a type not compatible with
+     * the given type, then an
+     * <code>java.lang.IllegalStateException</code> will be thrown.
+     *
+     * @param <T> The type of exception the task is expected to throw.
+     *
+     * @param expectedExceptionClass The class of the exception the task
+     * is expected to throw. This can be wither a checked or an unchecked
+     * exception.
+     *
+     * @param task The runnable that will be excuted,
+     *
+     * @return The exception thrown during the execution of the given task.
+     *
+     * @throws IllegalStateException When the task throws an exception,
+     * but it is of a type not compatible with
+     * <code>expectedExceptionClass</code>.
+     */
+    public static <T extends Throwable> T assertThrows(
+            final Class<T> expectedExceptionClass,
+            final TestTask task) {
 
         T result = null;
 
@@ -85,22 +159,20 @@ public final class TestUtils
             } else {
                 // Uh, oh... The wrong exception was thrown. Let us
                 // blow up with yet another one!
-                String msgFmt = "Expected exception {0} but got {1}";
-                Object[] fmtArgs = {
-                    expectedExceptionClass.getName(),
-                    actualException.getClass().getName()
-                };
-                String msg = MessageFormat.format(msgFmt, fmtArgs);
-
+                String msg =
+                        MessageFormat.format(
+                                "Expected exception {0} but got {1}",
+                                expectedExceptionClass.getName(),
+                                actualException.getClass().getName());
                 throw new IllegalStateException(msg, actualException);
             }
         }
 
         if ( result == null ) {
-            String msgFmt = "Failed to throw expected exception ";
-            Object[] fmtArgs = { expectedExceptionClass.getName() };
-            String msg = MessageFormat.format(msgFmt, fmtArgs);
-
+            String msg =
+                    MessageFormat.format(
+                            "Failed to throw expected exception {0}",
+                            expectedExceptionClass.getName());
             Assert.fail(msg);
         }
 
@@ -108,43 +180,20 @@ public final class TestUtils
     }
 
 
-
-
-
-/**************************************************************************
- *
- * A runnable simile that throws a checked exception. Used for
- * simplifying the use of lambdas when calling <code>{@link
- * #assertThrows(Class, TestTask)}</code>.
- *
- **************************************************************************/
-
+    /**
+     * A runnable simile that throws a checked exception. Used for
+     * simplifying the use of lambdas when calling <code>{@link
+     * #assertThrows(Class, TestTask)}</code>.
+     */
     @FunctionalInterface
     public interface TestTask {
 
 
-
-
-
-/**************************************************************************
- *
- * @throws Exception Checked exception.
- *
- **************************************************************************/
-
+        /**
+         * @throws Exception Checked exception.
+         */
         void run() throws Exception;
     }
 
 
 }
-
-
-
-
-
-/**************************************************************************
- *
- * 
- *
- **************************************************************************/
-


### PR DESCRIPTION
There is a new "includeOnly" configuration parameter recognized in the
'.yawg.yml' file per directory. Its value is expected to be a list of
strings representing regexp patterns.

Files whose base names match any of the regexp patterns specified with
the "includeOnly" parameter will be processed during the bake. No
other files will be baked. The "includeOnly" paramater thus define the
strict list of files to be baked in that directory.

The "includeOnly" parameter is not cascaded to sub-directories.