### PR TITLE
Refs #97 Improved error message on failure to parse dir baker config …

### DIFF
--- a/conf/yawg-defaults.conf
+++ b/conf/yawg-defaults.conf
@@ -19,7 +19,7 @@
 # MUST run devtools/bin/bild-sync-version to propagate the change to
 # other source files.
 #
-YAWG_MAIN_VERSION=0.1.0
+YAWG_MAIN_VERSION=0.9.0
 
 
 #

--- a/doc/content/.yawg.yml
+++ b/doc/content/.yawg.yml
@@ -3,17 +3,17 @@
 #
 
 ignore:
-  - '*~'
-  - '*.~'
-  - '*.aux'
-  - '*.bak'
-  - '*.log'
-  - '*.out'
-  - '*.pid'
-  - 'target'
-  - 'work'
-  - '.*~$'
-  - '.yawg.yml'
+  - "*~"
+  - "*.~"
+  - "*.aux"
+  - "*.bak"
+  - "*.log"
+  - "*.out"
+  - "*.pid"
+  - "target"
+  - "work"
+  - ".*~$"
+  - ".yawg.yml
 
 
 templateVars:

--- a/modules/cli/pom.xml
+++ b/modules/cli/pom.xml
@@ -13,7 +13,7 @@ Copyright (c) 2015-2016 Jorge Nunes, All Rights Reserved.
   <parent>
     <groupId>com.varmateo.yawg</groupId>
     <artifactId>yawg-main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -15,7 +15,7 @@ Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
   <parent>
     <groupId>com.varmateo.yawg</groupId>
     <artifactId>yawg-main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/modules/core/src/main/java/com/varmateo/yawg/DirBakerConfDao.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/DirBakerConfDao.java
@@ -121,7 +121,7 @@ import com.varmateo.yawg.util.yaml.YamlParser;
      *
      */
     /* package private */ DirBakerConf read(final Reader reader)
-            throws YawgException {
+            throws IOException, YawgException {
 
         YamlMap map = new YamlParser().parse(reader);
         DirBakerConf.Builder builder = new DirBakerConf.Builder();

--- a/modules/core/src/main/java/com/varmateo/yawg/util/yaml/YamlParser.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/util/yaml/YamlParser.java
@@ -6,6 +6,7 @@
 
 package com.varmateo.yawg.util.yaml;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.util.Collections;
 import java.util.Map;
@@ -13,7 +14,6 @@ import java.util.Map;
 import com.esotericsoftware.yamlbeans.YamlException;
 import com.esotericsoftware.yamlbeans.YamlReader;
 
-import com.varmateo.yawg.YawgException;
 import com.varmateo.yawg.util.yaml.YamlMap;
 
 
@@ -41,33 +41,11 @@ public final class YamlParser
      * @return A map with the results of parsing the given YAML
      * content.
      *
-     * @exception YawgException Thrown if there were any problems
+     * @exception IOException Thrown if there were any problems
      * reading from the reader, or if the YAML contents are invalid.
      */
     public YamlMap parse(final Reader reader)
-            throws YawgException {
-
-        YamlMap result = null;
-
-        try {
-            result = doParse(reader);
-        } catch ( YamlException e ) {
-            YawgException.raise(
-                    e,
-                    "Failed to parse YAML content - {0} - {1}",
-                    e.getClass().getSimpleName(),
-                    e.getMessage());
-        }
-
-        return result;
-    }
-
-
-    /**
-     *
-     */
-    private YamlMap doParse(final Reader reader)
-            throws YamlException {
+            throws IOException {
 
         Map<String,Object> resultMap = null;
         YamlReader yamlReader = new YamlReader(reader);

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -11,7 +11,7 @@ Copyright (c) 2015-2016 Jorge Nunes, All Rights Reserved.
 
   <groupId>com.varmateo.yawg</groupId>
   <artifactId>yawg-main</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
 
 

--- a/modules/release/pom.xml
+++ b/modules/release/pom.xml
@@ -15,7 +15,7 @@ Maven POM for the "release" sub-project of the Yawg project.
   <parent>
     <groupId>com.varmateo.yawg</groupId>
     <artifactId>yawg-main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/modules/testutils/pom.xml
+++ b/modules/testutils/pom.xml
@@ -15,7 +15,7 @@ Copyright (c) 2016 Jorge Nunes, All Rights Reserved.
   <parent>
     <groupId>com.varmateo.yawg</groupId>
     <artifactId>yawg-main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
…file

The error message displayed on failure to parse a directory baker
cofniguration file now contains the path of the file.

This change makes more transparent to the end user which file was the
cause of the problems.