### PR TITLE
Refs #183 Added support for baking additional dirs outside root sourc…

### DIFF
--- a/doc/content/.yawg.yml
+++ b/doc/content/.yawg.yml
@@ -26,3 +26,4 @@ pageVarsHere:
   breadcrumb:
     title: "Home"
     url: "index.html"
+

--- a/doc/content/Documentation/UserGuide/UserGuide.adoc
+++ b/doc/content/Documentation/UserGuide/UserGuide.adoc
@@ -214,6 +214,14 @@ to be baked by that baker type.
 files in the directory that are to be excluded from the bake. These
 files will not be processed in any way.
 
+* `extraDirsHere` - List of additional directories to be baked
+into the current target directory. The elements of the list are file
+system paths of directories. If a path is relative it is taken as
+being relative to the directory currently being baked. Only the
+content of the extra source directories is baked into the current
+target directory. The target directory will not contain a directory
+with the same name as the extra directory.
+
 * `includeHere` (`List<String>`) -- List of glob patterns representing
 the files in the directory that are to be baked. All other files in
 the directory will be skipped. This parameter takes precedence over

--- a/modules/core/src/main/java/com/varmateo/yawg/core/DirBakerConf.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/DirBakerConf.java
@@ -6,13 +6,17 @@
 
 package com.varmateo.yawg.core;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 
 import com.varmateo.yawg.PageVars;
 
 import com.varmateo.yawg.core.TemplateNameMatcher;
 import com.varmateo.yawg.util.GlobMatcher;
+import com.varmateo.yawg.util.Lists;
 
 
 /**
@@ -67,6 +71,12 @@ import com.varmateo.yawg.util.GlobMatcher;
     /**
      *
      */
+    public final Collection<Path> extraDirsHere;
+
+
+    /**
+     *
+     */
     private DirBakerConf(final Builder builder) {
 
         this.templateName = builder._templateName;
@@ -76,6 +86,7 @@ import com.varmateo.yawg.util.GlobMatcher;
         this.pageVars = builder._pageVarsBuilder.build();
         this.pageVarsHere = builder._pageVarsHere;
         this.templatesHere = builder._templatesHere;
+        this.extraDirsHere = Lists.readOnlyCopy(builder._extraDirsHere);
     }
 
 
@@ -113,7 +124,8 @@ import com.varmateo.yawg.util.GlobMatcher;
         builder
                 .addPageVars(this.pageVars)
                 .setPageVarsHere(this.pageVarsHere)
-                .setTemplatesHere(this.templatesHere);
+                .setTemplatesHere(this.templatesHere)
+                .setExtraDirsHere(this.extraDirsHere);
 
 
         DirBakerConf result = builder.build();
@@ -140,6 +152,7 @@ import com.varmateo.yawg.util.GlobMatcher;
         private Optional<GlobMatcher> _filesToExclude;
         private Optional<BakerMatcher> _bakerTypes;
         private PageVars.Builder _pageVarsBuilder;
+        private Collection<Path> _extraDirsHere;
 
 
         /**
@@ -151,6 +164,7 @@ import com.varmateo.yawg.util.GlobMatcher;
             _filesToExclude = Optional.empty();
             _bakerTypes = Optional.empty();
             _pageVarsBuilder = PageVars.builder();
+            _extraDirsHere = new ArrayList<>();
         }
 
 
@@ -163,6 +177,7 @@ import com.varmateo.yawg.util.GlobMatcher;
             _filesToExclude = defaults.filesToExclude;
             _bakerTypes = defaults.bakerTypes;
             _pageVarsBuilder = PageVars.builder(defaults.pageVars);
+            _extraDirsHere = new ArrayList<>(defaults.extraDirsHere);
         }
 
 
@@ -340,6 +355,18 @@ import com.varmateo.yawg.util.GlobMatcher;
                 final TemplateNameMatcher templatesHere) {
 
             _templatesHere = templatesHere;
+
+            return this;
+        }
+
+
+        /**
+         *
+         */
+        public Builder setExtraDirsHere(
+                final Collection<Path> extraDirsHere) {
+
+            _extraDirsHere = new ArrayList<>(extraDirsHere);
 
             return this;
         }

--- a/modules/core/src/main/java/com/varmateo/yawg/core/DirPageContextBuilder.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/DirPageContextBuilder.java
@@ -29,7 +29,7 @@ import com.varmateo.yawg.core.TemplateNameMatcher;
         extends Object {
 
 
-    private final Path _sourceRootDir;
+    private final Path _targetRootDir;
     private final TemplateService _templateService;
 
 
@@ -37,10 +37,10 @@ import com.varmateo.yawg.core.TemplateNameMatcher;
      *
      */
     public DirPageContextBuilder(
-            final Path sourceRootDir,
+            final Path targetRootDir,
             final TemplateService templateService) {
 
-        _sourceRootDir = sourceRootDir;
+        _targetRootDir = targetRootDir;
         _templateService = templateService;
     }
 
@@ -49,15 +49,15 @@ import com.varmateo.yawg.core.TemplateNameMatcher;
      *
      */
     public PageContext buildPageContext(
-            final Path sourceDir,
+            final Path targetDir,
             final DirBakerConf dirBakerConf,
             final PageVars extensionVars)
             throws YawgException {
 
         Function<Path,Optional<Template>> templateFetcher =
                 buildTemplateFetcher(dirBakerConf);
-        String dirUrl = buildRelativeUrl(sourceDir, _sourceRootDir);
-        String rootRelativeUrl = buildRelativeUrl(_sourceRootDir, sourceDir);
+        String dirUrl = buildRelativeUrl(targetDir, _targetRootDir);
+        String rootRelativeUrl = buildRelativeUrl(_targetRootDir, targetDir);
         PageVars allPageVars =
                 PageVars.builder()
                 .addPageVars(extensionVars)

--- a/modules/core/src/main/java/com/varmateo/yawg/core/FileBaker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/FileBaker.java
@@ -27,7 +27,6 @@ import com.varmateo.yawg.util.Exceptions;
 
 
     private final Log _log;
-    private final Path _sourceRootDir;
     private final Collection<Baker> _bakers;
     private final Baker _defaultBaker;
 
@@ -38,17 +37,13 @@ import com.varmateo.yawg.util.Exceptions;
 
     /**
      * @param log The logger that will be used for logging.
-     *
-     * @param sourceRootDir The top level directory being baked.
      */
     public FileBaker(
             final Log log,
-            final Path sourceRootDir,
             final Collection<Baker> bakers,
             final Baker defaultBaker) {
 
         _log = log;
-        _sourceRootDir = sourceRootDir;
         _bakers = bakers;
         _defaultBaker = defaultBaker;
         _allBakersByType = new HashMap<>();

--- a/modules/core/src/main/java/com/varmateo/yawg/core/SiteBakerDomain.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/SiteBakerDomain.java
@@ -138,6 +138,7 @@ import com.varmateo.yawg.util.Services;
                 new DirBaker(
                         _log.get(),
                         _conf.getSourceDir(),
+                        _conf.getTargetDir(),
                         _fileBaker.get(),
                         _templateService.get(),
                         _dirBakerConfDao.get(),
@@ -163,11 +164,9 @@ import com.varmateo.yawg.util.Services;
     private FileBaker newFileBaker() {
 
         Log log = _log.get();
-        Path sourceRootDir = _conf.getSourceDir();
         Collection<Baker> bakers = _bakers.get();
         Baker defaultBaker = _copyBaker.get();
-        FileBaker result =
-                new FileBaker(log, sourceRootDir, bakers, defaultBaker);
+        FileBaker result = new FileBaker(log, bakers, defaultBaker);
 
         return result;
     }

--- a/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerTest.java
@@ -88,7 +88,7 @@ public final class DirBakerTest
         Path sourceDir = TestUtils.getPath(DirBaker.class, "source01");
         Path targetDir = Paths.get(".");
         MockBaker mockBaker = new MockBaker();
-        DirBaker baker = buildDirBaker(sourceDir, mockBaker);
+        DirBaker baker = buildDirBaker(sourceDir, targetDir, mockBaker);
 
         baker.bakeDirectory(sourceDir, targetDir, conf);
 
@@ -111,7 +111,7 @@ public final class DirBakerTest
         Path sourceDir = TestUtils.getPath(DirBaker.class, "source02");
         Path targetDir = Paths.get(".");
         MockBaker mockBaker = new MockBaker();
-        DirBaker baker = buildDirBaker(sourceDir, mockBaker);
+        DirBaker baker = buildDirBaker(sourceDir, targetDir, mockBaker);
 
         baker.bakeDirectory(sourceDir, targetDir, _emptyConf);
 
@@ -130,19 +130,20 @@ public final class DirBakerTest
      */
     private DirBaker buildDirBaker(
             final Path sourceRootDir,
+            final Path targetRootDir,
             final Baker baker) {
 
         Log log = LogFactory.createFor(DirBaker.class);
         FileBaker fileBaker =
                 new FileBaker(
                         log,
-                        sourceRootDir,
                         Collections.emptyList(),
                         baker);
         DirBaker result =
                 new DirBaker(
                         log,
                         sourceRootDir,
+                        targetRootDir,
                         fileBaker,
                         _templateService,
                         _confDao,


### PR DESCRIPTION
…e dir

There is a new dir baker configuration parameter called
`extraDirsHere`. This is a list of additional directories to be baked
into the current target directory. The elements of the list are file
system paths of directories. If a path is relative it is taken as
being relative to the directory currently being baked.