### PR TITLE
Refs #188 Added support to define page vars from the command line

### DIFF
--- a/devtools/bin/build-site
+++ b/devtools/bin/build-site
@@ -30,6 +30,7 @@ DEFAULT_COMMIT_COMMENT="Doc updates"
 _workingArea=
 _isInit=false
 _isCommit=false
+_isProduction=false
 _yawgTool=${_yawgHome}/bin/yawg
 _commitComment=${DEFAULT_COMMIT_COMMENT}
 
@@ -75,6 +76,10 @@ function processCliArgs () {
                 ;;
             --commit )
                 _isCommit=true
+                _isProduction=true;
+                ;;
+            --production )
+                _isProduction=true;
                 ;;
             --yawg=* )
                 _yawgTool=$(expr "$option" : '--yawg=\(.*\)')
@@ -120,7 +125,12 @@ Available options:
 
 --commit
     Commit changes to the site branch and uploads to Git origin
-    repository.
+    repository. Implies --production
+
+--production
+    Generates the site ready for uploading to the production
+    location. If not specified a visual indicator is added to the site
+    to inform readers that it is not an official release.
 
 --yawg
     Path of the'yawg' tool to be used. By default it will use the
@@ -233,10 +243,11 @@ function doBaking () {
     fi
 
     ${_yawgTool} \
-        --source=$(yawgNormalizePath ${_yawgHome}/doc/content) \
-        --target=$(yawgNormalizePath ${_workingArea}) \
-        --templates=$(yawgNormalizePath ${_yawgHome}/doc/templates) \
-        --assets=$(yawgNormalizePath ${_yawgHome}/doc/assets) \
+        --source $(yawgNormalizePath ${_yawgHome}/doc/content) \
+        --target $(yawgNormalizePath ${_workingArea}) \
+        --templates $(yawgNormalizePath ${_yawgHome}/doc/templates) \
+        --assets $(yawgNormalizePath ${_yawgHome}/doc/assets) \
+        --page-var "isProduction=${_isProduction}" \
         --verbose
 }
 

--- a/doc/content/Documentation/UserGuide/UserGuide.adoc
+++ b/doc/content/Documentation/UserGuide/UserGuide.adoc
@@ -132,13 +132,14 @@ Usage: yawg [OPTION] ...
 Bakes a site from a directory tree.
  
 Options:
-    --assets <PATH>      path of assets directory
- -h,--help               show this help text and exit
-    --source <PATH>      path of source directory
-    --target <PATH>      path of target directory
-    --templates <PATH>   path of templates directory
- -v,--version            show version and exit
-    --verbose            show abundant logging
+    --assets <PATH>           path of assets directory
+ -h,--help                    show this help text and exit
+    --page-var <NAME=VALUE>   additional page variable
+    --source <PATH>           path of source directory
+    --target <PATH>           path of target directory
+    --templates <PATH>        path of templates directory
+ -v,--version                 show version and exit
+    --verbose                 show abundant logging
 
 Find additional information at http://yawg.varmateo.com/
 ----
@@ -149,6 +150,10 @@ The `bin/yawg` command supports the following command line options:
 this directory will be recursively copied to the target directory. The
 files under the assets directory are copied without any
 transformations.
+
+`--page-var <NAME=VALUE>` -- Defines a page variable that will be
+visible to the templates for all pages. The value of page variables
+defined through the option will always be strings.
 
 `--source <PATH>` -- Path to the directory containing the content
 source files to be baked.

--- a/doc/templates/yawg-navbar.ftlh
+++ b/doc/templates/yawg-navbar.ftlh
@@ -18,6 +18,12 @@
                name="developers"
                url="Developers/index.html"
                title="Developers" />
+
+            <#if (isProduction!"false") != "true">
+              <li style="float: right">
+                <a href="#"><span style="background:red; color:white; padding:0.5em;">TEST ENVIRONMENT</span></a>
+              </li>
+            </#if>
           </ul>
         </div><!--/.nav-collapse -->
       </div>

--- a/modules/api/src/main/java/com/varmateo/yawg/SiteBakerConf.java
+++ b/modules/api/src/main/java/com/varmateo/yawg/SiteBakerConf.java
@@ -10,6 +10,8 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.varmateo.yawg.PageVars;
+
 
 /**
  * Set of configuration parameters for baking a site with a
@@ -25,6 +27,7 @@ public final class SiteBakerConf
     private final Path _sourceDir;
     private final Path _targetDir;
     private final Optional<Path> _templatesDir;
+    private final PageVars _externalPageVars;
 
 
     /**
@@ -36,6 +39,7 @@ public final class SiteBakerConf
         _sourceDir = Objects.requireNonNull(builder._sourceDir);
         _targetDir = Objects.requireNonNull(builder._targetDir);
         _templatesDir = builder._templatesDir;
+        _externalPageVars = builder._externalPageVars;
     }
 
 
@@ -74,6 +78,14 @@ public final class SiteBakerConf
 
 
     /**
+     * Set oa page variables provided externally.
+     */
+    public PageVars getExternalPageVars() {
+        return _externalPageVars;
+    }
+
+
+    /**
      * Creates a new builder with no initializations.
      *
      * @return A newly created <code>Builder</code> instance.
@@ -97,6 +109,7 @@ public final class SiteBakerConf
         private Path _sourceDir = null;
         private Path _targetDir = null;
         private Optional<Path> _templatesDir = Optional.empty();
+        private PageVars _externalPageVars = new PageVars();
 
 
         /**
@@ -144,6 +157,16 @@ public final class SiteBakerConf
         public Builder setTemplatesDir(final Path templatesDir) {
 
             _templatesDir = Optional.ofNullable(templatesDir);
+            return this;
+        }
+
+
+        /**
+         *
+         */
+        public Builder setExternalPageVars(final PageVars externalPageVars) {
+
+            _externalPageVars = externalPageVars;
             return this;
         }
 

--- a/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCli.java
+++ b/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCli.java
@@ -17,6 +17,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.varmateo.yawg.PageVars;
 import com.varmateo.yawg.SiteBaker;
 import com.varmateo.yawg.SiteBakerConf;
 import com.varmateo.yawg.SiteBakerFactory;
@@ -139,20 +140,7 @@ public final class BakerCli
 
         setupLogging(cliOptions);
 
-        Path sourceDir = cliOptions.getPath(BakerCliOptions.SOURCE_DIR);
-        Path targetDir = cliOptions.getPath(BakerCliOptions.TARGET_DIR);
-        Path templatesDir =
-                cliOptions.getPath(BakerCliOptions.TEMPLATES_DIR, null);
-        Path assetsDir =
-                cliOptions.getPath(BakerCliOptions.ASSETS_DIR, null);
-
-        SiteBakerConf conf =
-                SiteBakerConf.builder()
-                .setSourceDir(sourceDir)
-                .setTargetDir(targetDir)
-                .setTemplatesDir(templatesDir)
-                .setAssetsDir(assetsDir)
-                .build();
+        SiteBakerConf conf = buildSiteBakerConf(cliOptions);
         SiteBakerFactory factory = SiteBakerFactory.get();
         SiteBaker siteBaker = factory.newSiteBaker();
 
@@ -187,6 +175,62 @@ public final class BakerCli
         logger.addHandler(handler);
         logger.setLevel(Level.FINEST);
         logger.setUseParentHandlers(false);
+    }
+
+
+    /**
+     *
+     */
+    private SiteBakerConf buildSiteBakerConf(final CliOptions cliOptions)
+            throws CliException {
+
+        Path sourceDir = cliOptions.getPath(BakerCliOptions.SOURCE_DIR);
+        Path targetDir = cliOptions.getPath(BakerCliOptions.TARGET_DIR);
+        Path templatesDir =
+                cliOptions.getPath(BakerCliOptions.TEMPLATES_DIR, null);
+        Path assetsDir =
+                cliOptions.getPath(BakerCliOptions.ASSETS_DIR, null);
+        PageVars externalPageVars = buildExternalPageVars(cliOptions);
+
+        SiteBakerConf conf =
+                SiteBakerConf.builder()
+                .setSourceDir(sourceDir)
+                .setTargetDir(targetDir)
+                .setTemplatesDir(templatesDir)
+                .setAssetsDir(assetsDir)
+                .setExternalPageVars(externalPageVars)
+                .build();
+
+        return conf;
+    }
+
+
+    /**
+     *
+     */
+    private PageVars buildExternalPageVars(final CliOptions cliOptions) {
+
+        PageVars.Builder builder = PageVars.builder();
+
+        for ( String optionValue : cliOptions.getAll(BakerCliOptions.PAGE_VAR)){
+            String varName = null;
+            String varValue = null;
+            int indexOfEqSign = optionValue.indexOf('=');
+
+            if ( indexOfEqSign < 0 ) {
+                varName = optionValue;
+                varValue = "";
+            } else {
+                varName = optionValue.substring(0, indexOfEqSign);
+                varValue = optionValue.substring(indexOfEqSign+1);
+            }
+
+            builder.addVar(varName, varValue);
+        }
+
+        PageVars result = builder.build();
+
+        return result;
     }
 
 

--- a/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCliOptions.java
+++ b/modules/cli/src/main/java/com/varmateo/yawg/cli/BakerCliOptions.java
@@ -38,6 +38,13 @@ import com.varmateo.yawg.cli.util.CliOptions;
         .setShortName("h")
         .build();
 
+    public static final CliOption PAGE_VAR =
+        CliOption.builder()
+        .setLongName("page-var")
+        .setArgName("NAME=VALUE")
+        .setDescription("additional page variable")
+        .build();
+
     public static final CliOption SOURCE_DIR =
         CliOption.builder()
         .setLongName("source")
@@ -88,6 +95,7 @@ import com.varmateo.yawg.cli.util.CliOptions;
         CliOption[] allOptions = {
             ASSETS_DIR,
             HELP,
+            PAGE_VAR,
             SOURCE_DIR,
             TARGET_DIR,
             TEMPLATES_DIR,

--- a/modules/cli/src/main/java/com/varmateo/yawg/cli/util/CliOptions.java
+++ b/modules/cli/src/main/java/com/varmateo/yawg/cli/util/CliOptions.java
@@ -9,6 +9,7 @@ package com.varmateo.yawg.cli.util;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -162,10 +163,44 @@ public final class CliOptions
 
 
     /**
+     * Retrieves all the values for an option.
+     *
+     * <p>An option will have multiple values when it is given more
+     * than onde in the list of command line arguments.</p>
+     *
+     * @param option The name of the option whose values are to be
+     * returned.
+     *
+     * @return A list with the values of the given option, in the same
+     * order theay appeared in the command line. It will be empty if
+     * the option was not given in the command line.
+     */
+    public List<String> getAll(final CliOption option) {
+
+        List<String> result = null;
+        String   optionName   = option.getName();
+        String[] optionValues = _cmdLine.getOptionValues(optionName);
+
+        if ( optionValues != null ) {
+            result = Arrays.asList(optionValues);
+        } else {
+            result = Collections.emptyList();
+        }
+
+        return result;
+    }
+
+
+    /**
      * Retrieves the value of a mandatory option.
+     *
+     * <p>If the given option does not exist, then a
+     * <code>CliException</code> will be thrown.
      *
      * @param option The name (short or long) of the option whose
      * value is to be retrieved.
+     *
+     * @return The value of the given option.
      *
      * @exception CliException Thrown if the given command line does
      * not contain the option.

--- a/modules/core/src/main/java/com/varmateo/yawg/core/SingleSiteBaker.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/SingleSiteBaker.java
@@ -15,6 +15,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Optional;
 
+import com.varmateo.yawg.PageVars;
 import com.varmateo.yawg.SiteBakerConf;
 import com.varmateo.yawg.YawgException;
 import com.varmateo.yawg.YawgInfo;
@@ -107,9 +108,11 @@ import com.varmateo.yawg.util.Exceptions;
 
         Path sourceDir = _conf.getSourceDir();
         Path targetDir = _conf.getTargetDir();
+        PageVars externalPageVars = _conf.getExternalPageVars();
         DirBakerConf dirBakerConf =
                 DirBakerConf.builder()
                 .setTemplateName(DEFAULT_TEMPLATE_NAME)
+                .setPageVars(externalPageVars)
                 .build();
 
         _dirBaker.bakeDirectory(sourceDir, targetDir, dirBakerConf);


### PR DESCRIPTION
There is a new --page-var command line option to define page vars from
the command line. The values of page vars defined this way will always
be strings.