### PR TITLE
Refs #214 Minor builder refactorings for simpler empty POJOs

### DIFF
--- a/doc/content/Acknowledgements.html
+++ b/doc/content/Acknowledgements.html
@@ -37,6 +37,8 @@
         <ul>
           <li><a href="https://maven.apache.org/">Apache Maven</a> -
           Build tool.</li>
+          <li><a href="http://joel-costigliola.github.io/assertj/index.html">AssertJ</a>
+          - Rich set of assertions for testing.</li>
           <li><a href="http://checkstyle.sourceforge.net/">Checkstyle</a>
           - Static code analysis tool helping with adhering to code
           quality standards.</li>
@@ -47,6 +49,8 @@
           system.</li>
           <li><a href="http://www.eclemma.org/jacoco/">JaCoCo</a> -
           Code coverage library.</li>
+          <li><a href="http://site.mockito.org/">Mockito</a> - Mocking
+          framework for testing.</li>
           <li><a href="http://junit.org/">JUnit</a> - Unit testing
           framework.</li>
           <li><a href="https://pmd.github.io/">PMD</a> - Source code

--- a/modules/acceptance/pom.xml
+++ b/modules/acceptance/pom.xml
@@ -27,7 +27,13 @@ Copyright (c) 2016 Yawg project contributors.
 
   <dependencies>
 
-    <!-- JUnit -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/modules/acceptance/src/test/java/com/varmateo/yawg/atests/BakerRunner.java
+++ b/modules/acceptance/src/test/java/com/varmateo/yawg/atests/BakerRunner.java
@@ -37,6 +37,17 @@ public final class BakerRunner {
     /**
      *
      */
+    public static BakerRunner empty() {
+
+        BakerRunner result = BakerRunner.builder().build();
+
+        return result;
+    }
+
+
+    /**
+     *
+     */
     private BakerRunner(final Builder builder) {
 
         _args = Lists.toArray(builder._args, String.class);

--- a/modules/acceptance/src/test/java/com/varmateo/yawg/atests/CliOptionsIT.java
+++ b/modules/acceptance/src/test/java/com/varmateo/yawg/atests/CliOptionsIT.java
@@ -6,12 +6,11 @@
 
 package com.varmateo.yawg.atests;
 
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
 import com.varmateo.yawg.YawgInfo;
-
 import com.varmateo.yawg.atests.BakerRunner;
 import com.varmateo.yawg.atests.BakerRunnerResult;
 
@@ -28,17 +27,14 @@ public final class CliOptionsIT {
     @Test
     public void noArgs() {
 
-        BakerRunner baker = BakerRunner.builder().build();
+        BakerRunner baker = BakerRunner.empty();
         BakerRunnerResult bakerResult = baker.run();
 
         int actualExitStatus = bakerResult.getExitStatus();
-        assertEquals(0, actualExitStatus);
+        assertThat(0).isEqualTo(actualExitStatus);
 
         String actualFirstLine = bakerResult.outputLine(1);
-        assertThat(
-                "Contains version string",
-                actualFirstLine,
-                containsString(YawgInfo.VERSION));
+        assertThat(actualFirstLine).contains(YawgInfo.VERSION);
     }
 
 
@@ -55,13 +51,10 @@ public final class CliOptionsIT {
         BakerRunnerResult bakerResult = baker.run();
 
         int actualExitStatus = bakerResult.getExitStatus();
-        assertNotEquals(0, actualExitStatus);
+        assertThat(0).isNotEqualTo(actualExitStatus);
 
         String actualFirstLine = bakerResult.outputLine(1);
-        assertThat(
-                "Contains unknown option message",
-                actualFirstLine,
-                containsString("unknown option"));
+        assertThat(actualFirstLine).contains("unknown option");
     }
 
 

--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -4,7 +4,7 @@
 Copyright (c) 2016 Yawg project contributors.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>jar</packaging>
@@ -27,7 +27,13 @@ Copyright (c) 2016 Yawg project contributors.
 
   <dependencies>
 
-    <!-- JUnit -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/modules/api/src/main/java/com/varmateo/yawg/PageContext.java
+++ b/modules/api/src/main/java/com/varmateo/yawg/PageContext.java
@@ -28,6 +28,19 @@ public final class PageContext {
 
 
     /**
+     * Creates a new builder with an empty initialization.
+     *
+     * @return The new <code>Builder</code> object.
+     */
+    public static Builder builder() {
+
+        Builder result = new Builder();
+
+        return result;
+    }
+
+
+    /**
      *
      */
     private PageContext(final Builder builder) {
@@ -74,19 +87,6 @@ public final class PageContext {
      */
     public String getRootRelativeUrl() {
         return _rootRelativeUrl;
-    }
-
-
-    /**
-     * Creates a new builder with an empty initialization.
-     *
-     * @return The new <code>Builder</code> object.
-     */
-    public static Builder builder() {
-
-        Builder result = new Builder();
-
-        return result;
     }
 
 

--- a/modules/api/src/test/java/com/varmateo/yawg/PageContextTest.java
+++ b/modules/api/src/test/java/com/varmateo/yawg/PageContextTest.java
@@ -8,7 +8,9 @@ package com.varmateo.yawg;
 
 import java.nio.file.Paths;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import com.varmateo.testutils.TestUtils;
@@ -29,9 +31,8 @@ public final class PageContextTest
     @Test
     public void missingMandatoryAttrs() {
 
-        TestUtils.assertThrows(
-                NullPointerException.class,
-                () -> PageContext.builder().build());
+        assertThatThrownBy(() -> PageContext.builder().build())
+                .isInstanceOf(NullPointerException.class);
     }
 
 
@@ -47,10 +48,10 @@ public final class PageContextTest
                 .setRootRelativeUrl("whatever")
                 .build();
 
-        assertEquals("something", context.getDirUrl());
-        assertEquals("whatever", context.getRootRelativeUrl());
-        assertFalse(context.getTemplateFor(Paths.get("xxx")).isPresent());
-        assertTrue(context.getPageVars().asMap().isEmpty());
+        assertThat(context.getDirUrl()).isEqualTo("something");
+        assertThat(context.getRootRelativeUrl()).isEqualTo("whatever");
+        assertThat(context.getTemplateFor(Paths.get("xxx"))).isNotPresent();
+        assertThat(context.getPageVars().asMap()).isEmpty();
     }
 
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -29,7 +29,13 @@ Maven POM for the "core" sub-project of the Yawg project.
 
   <dependencies>
 
-    <!-- JUnit -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/modules/core/src/main/java/com/varmateo/yawg/core/DirBakerConf.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/DirBakerConf.java
@@ -68,7 +68,9 @@ import com.varmateo.yawg.util.GlobMatcher;
 
 
     /**
-     *
+     * Collection of additional directories with content to be baked. The bake results
+     * from those directories will be placed in the same location as the bake results from
+     * the directory currently being baked.
      */
     public final Collection<Path> extraDirsHere;
 
@@ -97,6 +99,17 @@ import com.varmateo.yawg.util.GlobMatcher;
     public static Builder builder() {
 
         Builder result = new Builder();
+
+        return result;
+    }
+
+
+    /**
+     *
+     */
+    public static DirBakerConf empty() {
+
+        DirBakerConf result = DirBakerConf.builder().build();
 
         return result;
     }

--- a/modules/core/src/main/java/com/varmateo/yawg/core/DirBakerConfDao.java
+++ b/modules/core/src/main/java/com/varmateo/yawg/core/DirBakerConfDao.java
@@ -80,7 +80,7 @@ import com.varmateo.yawg.util.YamlParser;
         if ( Files.isRegularFile(confFile) ) {
             result = loadFromFile(confFile);
         } else {
-            result = DirBakerConf.builder().build();
+            result = DirBakerConf.empty();
         }
 
         return result;

--- a/modules/core/src/test/java/com/varmateo/yawg/asciidoctor/AsciidoctorBakerIT.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/asciidoctor/AsciidoctorBakerIT.java
@@ -22,7 +22,6 @@ import com.varmateo.yawg.PageContext;
 import com.varmateo.yawg.Template;
 import com.varmateo.yawg.YawgException;
 
-import com.varmateo.yawg.MockTemplate;
 import com.varmateo.yawg.asciidoctor.AsciidoctorBaker;
 
 

--- a/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerConfDaoTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerConfDaoTest.java
@@ -14,7 +14,9 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +36,7 @@ public final class DirBakerConfDaoTest
  {
 
 
-    private final DirBakerConf _emptyConf = DirBakerConf.builder().build();
+    private final DirBakerConf _emptyConf = DirBakerConf.empty();
     private DirBakerConfDao _dao = null;
 
 
@@ -86,7 +88,7 @@ public final class DirBakerConfDaoTest
     @Test
     public void withTemplateParamMissing() {
 
-        assertFalse(_emptyConf.templateName.isPresent());
+        assertThat(_emptyConf.templateName).isNotPresent();
     }
 
 
@@ -101,9 +103,8 @@ public final class DirBakerConfDaoTest
                 + "template: \n"
                 + "  - something: wrong";
 
-        TestUtils.assertThrows(
-                YawgException.class,
-                () -> readFromString(confContents));
+        assertThatThrownBy(() -> readFromString(confContents))
+                .isInstanceOf(YawgException.class);
     }
 
 
@@ -135,7 +136,7 @@ public final class DirBakerConfDaoTest
     public void withExcludeParamMissing()
             throws IOException {
 
-        assertFalse(_emptyConf.filesToExclude.isPresent());
+        assertThat(_emptyConf.filesToExclude).isNotPresent();
     }
 
 
@@ -148,11 +149,10 @@ public final class DirBakerConfDaoTest
 
         String confContents = ""
                 + "exclude: \n"
-                + "  - something: wrong"; 
+                + "  - something: wrong";
 
-        TestUtils.assertThrows(
-                YawgException.class,
-                () -> readFromString(confContents));
+        assertThatThrownBy(() -> readFromString(confContents))
+                .isInstanceOf(YawgException.class);
     }
 
 
@@ -167,9 +167,8 @@ public final class DirBakerConfDaoTest
                 + "exclude: \n"
                 + "  - \"[\""; 
 
-        TestUtils.assertThrows(
-                YawgException.class,
-                () -> readFromString(confContents));
+        assertThatThrownBy(() -> readFromString(confContents))
+                .isInstanceOf(YawgException.class);
     }
 
 
@@ -200,7 +199,7 @@ public final class DirBakerConfDaoTest
     @Test
     public void withIncludeHereParamMissing() {
 
-        assertFalse(_emptyConf.filesToIncludeHere.isPresent());
+        assertThat(_emptyConf.filesToIncludeHere).isNotPresent();
     }
 
 
@@ -243,9 +242,9 @@ public final class DirBakerConfDaoTest
         PageVars vars = actualConf.pageVars;
         Optional<Object> value = vars.get("hello");
 
-        assertTrue(value.isPresent());
-        assertTrue(value.get() instanceof String);
-        assertEquals("world", value.get());
+        assertThat(value).isPresent();
+        assertThat(value).containsInstanceOf(String.class);
+        assertThat(value).hasValue("world");
     }
 
 
@@ -263,9 +262,9 @@ public final class DirBakerConfDaoTest
         PageVars vars = actualConf.pageVarsHere;
         Optional<Object> value = vars.get("hello");
 
-        assertTrue(value.isPresent());
-        assertTrue(value.get() instanceof String);
-        assertEquals("world", value.get());
+        assertThat(value).isPresent();
+        assertThat(value).containsInstanceOf(String.class);
+        assertThat(value).hasValue("world");
     }
 
 
@@ -297,9 +296,8 @@ public final class DirBakerConfDaoTest
 
         Path noSuchPath = Paths.get("this/file/does/not/exist");
 
-        TestUtils.assertThrows(
-                YawgException.class,
-                () -> _dao.loadFromFile(noSuchPath));
+        assertThatThrownBy(() -> _dao.loadFromFile(noSuchPath))
+                .isInstanceOf(YawgException.class);
     }
 
 

--- a/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerConfTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerConfTest.java
@@ -6,9 +6,6 @@
 
 package com.varmateo.yawg.core;
 
-import java.util.Arrays;
-
-import static org.junit.Assert.*;
 import org.junit.Test;
 
 import static com.varmateo.yawg.core.DirBakerConfTestUtils.assertConfEquals;
@@ -29,7 +26,7 @@ public final class DirBakerConfTest
     @Test
     public void mergeFromEmpty() {
 
-        DirBakerConf confEmpty = DirBakerConf.builder().build();
+        DirBakerConf confEmpty = DirBakerConf.empty();
         DirBakerConf conf =
                 DirBakerConf.builder()
                 .setFilesToExclude("hello")

--- a/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/core/DirBakerTest.java
@@ -16,7 +16,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -165,7 +166,7 @@ public final class DirBakerTest
                 .map(Path::toString)
                 .collect(Collectors.toList());
 
-        assertEquals(expectedRelFiles, actualRelFiles);
+        assertThat(actualRelFiles).isEqualTo(expectedRelFiles);
     }
 
 

--- a/modules/core/src/test/java/com/varmateo/yawg/core/DirEntryCheckerTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/core/DirEntryCheckerTest.java
@@ -10,7 +10,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Predicate;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
 import com.varmateo.yawg.core.DirBakerConf;
@@ -30,10 +31,11 @@ public final class DirEntryCheckerTest
     @Test
     public void withEmptyConf() {
 
-        DirBakerConf conf = DirBakerConf.builder().build();
+        DirBakerConf conf = DirBakerConf.empty();
         DirEntryChecker checker = new DirEntryChecker(conf);
+        Predicate<String> predicate = checker.asStringPredicate();
 
-        assertTrue(checker.asStringPredicate().test("anything"));
+        assertThat(predicate).accepts("anything");
     }
 
 
@@ -50,8 +52,9 @@ public final class DirEntryCheckerTest
         DirEntryChecker checker = new DirEntryChecker(conf);
         Predicate<String> predicate = checker.asStringPredicate();
 
-        assertTrue(predicate.test("something.adoc"));
-        assertFalse(predicate.test("something.txt"));
+        assertThat(predicate)
+                .accepts("something.adoc")
+                .rejects("something.txt");
     }
 
 
@@ -68,10 +71,12 @@ public final class DirEntryCheckerTest
         DirEntryChecker checker = new DirEntryChecker(conf);
         Predicate<String> predicate = checker.asStringPredicate();
 
-        assertTrue(predicate.test("something.adoc"));
-        assertFalse(predicate.test("something.adoc~"));
-        assertFalse(predicate.test("something.txt"));
-        assertFalse(predicate.test("something.puml"));
+        assertThat(predicate)
+                .accepts("something.adoc")
+                .rejects(
+                        "something.adoc~",
+                        "something.txt",
+                        "something.puml");
     }
 
 
@@ -88,8 +93,9 @@ public final class DirEntryCheckerTest
         DirEntryChecker checker = new DirEntryChecker(conf);
         Predicate<String> predicate = checker.asStringPredicate();
 
-        assertTrue(predicate.test("something.adoc"));
-        assertFalse(predicate.test("something.txt"));
+        assertThat(predicate)
+                .accepts("something.adoc")
+                .rejects("something.txt");
     }
 
 
@@ -106,10 +112,13 @@ public final class DirEntryCheckerTest
         DirEntryChecker checker = new DirEntryChecker(conf);
         Predicate<String> predicate = checker.asStringPredicate();
 
-        assertTrue(predicate.test("something.adoc"));
-        assertTrue(predicate.test("something.svg"));
-        assertFalse(predicate.test("something.txt"));
-        assertFalse(predicate.test("something.puml"));
+        assertThat(predicate)
+                .accepts(
+                        "something.adoc",
+                        "something.svg")
+                .rejects(
+                        "something.txt",
+                        "something.puml");
     }
 
 
@@ -127,9 +136,11 @@ public final class DirEntryCheckerTest
         DirEntryChecker checker = new DirEntryChecker(conf);
         Predicate<String> predicate = checker.asStringPredicate();
 
-        assertTrue(predicate.test("something.adoc"));
-        assertFalse(predicate.test("something.txt"));
-        assertFalse(predicate.test("something.svg"));
+        assertThat(predicate)
+                .accepts("something.adoc")
+                .rejects(
+                        "something.txt",
+                        "something.svg");
     }
 
 
@@ -146,10 +157,13 @@ public final class DirEntryCheckerTest
         DirEntryChecker checker = new DirEntryChecker(conf);
         Predicate<Path> predicate = checker.asPathPredicate();
 
-        assertTrue(predicate.test(Paths.get("something.adoc")));
-        assertFalse(predicate.test(Paths.get("something.adoc/else.txt")));
-        assertFalse(predicate.test(Paths.get("something.txt")));
-        assertTrue(predicate.test(Paths.get("something.txt/else.adoc")));
+        assertThat(predicate)
+                .accepts(
+                        Paths.get("something.adoc"),
+                        Paths.get("something.txt/else.adoc"))
+                .rejects(
+                        Paths.get("something.adoc/else.txt"),
+                        Paths.get("something.txt"));
     }
 
 

--- a/modules/core/src/test/java/com/varmateo/yawg/core/DirEntryScannerTest.java
+++ b/modules/core/src/test/java/com/varmateo/yawg/core/DirEntryScannerTest.java
@@ -11,7 +11,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 
 import com.varmateo.testutils.TestUtils;
@@ -24,8 +25,7 @@ import com.varmateo.yawg.commons.util.Lists;
 /**
  *
  */
-public final class DirEntryScannerTest
- {
+public final class DirEntryScannerTest {
 
 
     /**
@@ -35,7 +35,7 @@ public final class DirEntryScannerTest
     public void allFiles()
             throws IOException {
 
-        DirBakerConf conf = DirBakerConf.builder().build();
+        DirBakerConf conf = DirBakerConf.empty();
         Path dirPath = TestUtils.getInputsDir(DirEntryScanner.class);
         DirEntryScanner scanner = new DirEntryScanner(conf);
         List<Path> actualEntries = scanner.getDirEntries(dirPath);
@@ -81,10 +81,10 @@ public final class DirEntryScannerTest
             final List<String> expectedNames,
             final List<Path> actualEntries) {
 
-        List<String> actualNames =
+        List<String> actualNames = 
                 Lists.map(actualEntries, p -> p.getFileName().toString());
 
-        assertEquals(actualNames, expectedNames);
+        assertThat(actualNames).isEqualTo(expectedNames);
     }
 
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -4,7 +4,7 @@
 Copyright (c) 2015-2016 Yawg project contributors.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                        http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
@@ -28,6 +28,7 @@ Copyright (c) 2015-2016 Yawg project contributors.
     <!-- Versions of dependencies and Maven plugins. -->
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <asciidoctorj-diagram.version>1.3.1</asciidoctorj-diagram.version>
+    <assertj-core.version>3.6.1</assertj-core.version>
     <commons-cli.version>1.2</commons-cli.version>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>

--- a/modules/testutils/src/main/java/com/varmateo/testutils/TestUtils.java
+++ b/modules/testutils/src/main/java/com/varmateo/testutils/TestUtils.java
@@ -19,12 +19,13 @@ import java.text.MessageFormat;
 public final class TestUtils {
 
 
-
-
-
+    // Name of system property with the path of the base directory containting input files
+    // to be used in testing.
     private static final String PROP_INPUTS_DIR_PREFIX =
             TestUtils.class.getSimpleName() + ".inputTestFilesDir";
 
+    // Name of system property with the path of the directory to be used for creating
+    // temporary files during testing.
     private static final String PROP_TMP_DIR_PREFIX =
             TestUtils.class.getSimpleName() + ".tmpTestFilesDir";
 


### PR DESCRIPTION
By convention a class with a builder now has a static `empty()` method
for simpler creation of instances.