### PR TITLE
Refs #228 Normalized target directory for auto-publishing Yawg site

### DIFF
--- a/devtools/bin/build-site
+++ b/devtools/bin/build-site
@@ -29,10 +29,11 @@ DEFAULT_COMMIT_COMMENT="Doc updates"
 
 _workingArea=
 _isInit=false
-_isCommit=false
+_isUpload=false
 _isProduction=false
 _yawgTool=${_yawgHome}/bin/yawg
 _commitComment=${DEFAULT_COMMIT_COMMENT}
+_outputDir=${_yawgHome}/target
 
 
 
@@ -48,7 +49,8 @@ function main () {
 
     processCliArgs "$@"
 
-    _workingArea=${_yawgHome}/../yawg.${SITE_BRANCH}
+    _workingArea=${_outputDir}/site
+    mkdir -p ${_workingArea}
 
     yawgLog "Building site..."
 
@@ -74,11 +76,12 @@ function processCliArgs () {
             --init )
                 _isInit=true
                 ;;
-            --commit )
-                _isCommit=true
+            --upload )
+                _isInit=true
+                _isUpload=true
                 _isProduction=true;
                 ;;
-            --production )
+            --final )
                 _isProduction=true;
                 ;;
             --yawg=* )
@@ -123,12 +126,12 @@ Available options:
 --init
     Initialize directory to be used as working area for site files.
 
---commit
-    Commit changes to the site branch and uploads to Git origin
-    repository. Implies --production
+--upload
+    Uploads the bake result to the Yawg site, replacing the previous
+    contents with the bake result. Implies --init and --final
 
---production
-    Generates the site ready for uploading to the production
+--final
+    Generates the site ready for uploading to the final production
     location. If not specified then a visual indicator is added to the
     site to inform readers that it is not an official release.
 
@@ -172,7 +175,7 @@ function doBakeSite () {
 
 function setupWorkingArea () {
 
-    if [ ${_isInit} == true -o ${_isCommit} == true ] ; then
+    if [ ${_isInit} == true -o ${_isUpload} == true ] ; then
         doSetupWorkingArea
     fi
 }
@@ -193,17 +196,17 @@ function doSetupWorkingArea () {
 
     local exitStatus=0
 
-    if [ ! -d ${_workingArea} ] ; then
+    if [ ! -d ${_workingArea}/.git ] ; then
+        rm -rf ${_workingArea}
         local username=$(git --git-dir ${_yawgHome}/.git config user.name)
         local email=$(git --git-dir ${_yawgHome}/.git config user.email)
 
-        mkdir ${_workingArea} || yawgError "Unable to created ${_workingArea}"
+        mkdir ${_workingArea} || yawgError "Unable to create ${_workingArea}"
         pushd ${_workingArea} > /dev/null
         true \
             && git clone -b ${SITE_BRANCH} ${SITE_REPO} . \
             && git config user.name ${username} \
-            && git config user.email ${email} \
-            && rm -rf ./*
+            && git config user.email ${email}
 
         exitStatus=$?
         popd  > /dev/null
@@ -239,7 +242,7 @@ function doBaking () {
             rm -rf ${_workingArea}/*
         fi
     else
-        yawgError "Directory \"${_workingArea}\" does not exist. Use --init."
+        mkdir ${_workingArea} || yawgError "Unable to create ${_workingArea}"
     fi
 
     ${_yawgTool} \
@@ -263,7 +266,7 @@ function doBaking () {
 
 function finalizeWorkingArea () {
 
-    if [ ${_isCommit} == true ] ; then
+    if [ ${_isUpload} == true ] ; then
         doFinalizeWorkingArea
     fi
 }

--- a/doc/content/Developers/SiteAutoPublishing.adoc
+++ b/doc/content/Developers/SiteAutoPublishing.adoc
@@ -1,0 +1,90 @@
+= Auto-publishing the Yawg site
+
+
+
+
+
+This document describes the setup and tools for auto-publishing the
+Yawg site.
+
+The Yawg site is hosted through the https://pages.github.com/[GitHub
+Pages] service provided by GitHub.
+
+To publish new content the changes must be commited to the `gh-pages`
+branch of the project. And then pushed to GitHub.
+
+The continuous integration build jobs are under the control of Travis
+CI.
+
+We will create a tool to perform the actions for publishing the Yawg
+site. This tool will be invoked in the build job run by Travis CI.
+
+The Yawg version to be used for baking the Yawg site will be a
+previously released version.
+
+The bake and publishing will only occur for merges into the
+mainline. This means only commits into the `master` branch will
+trigger the auto-publishing. Commits into feature branches and
+pull-requests will not trigger the auto-publishing.
+
+To ensure the auto-publishing is performed in the right context, it is
+important to strictly follow the workflow convention that the mainline
+branch (i.e. the `master` branch) only receives merges from feature
+branches.
+
+
+Steps in the auto-publishing procedure run within Travis CI:
+
+* If the build is not for a merge into the mainline, then there are no
+  more actions to perform.
+
+* If there are no changes in the current commit related with the site
+  (i.e. changes below `doc`) then there are no more actions to
+  perform.
+
+* Prepare the SSH key for access to GitHub
+  (cf. https://docs.travis-ci.com/user/deployment/custom/#Git).
+
+* Download and install the desired version of Yawg for baking the
+  site. The exact version to be used is a configuration parameter.
+
+* Create a workspace with the contents of the `gh-branch`.
+
+* Bake the Yawg site.
+
+* Commit and push the changes to GitHub, still in the `gh-granch`.
+
+
+
+
+
+Implementation steps:
+
+* Update `build-create-bundle` to place the `.tar.gz` and the code
+  quality reports into a `target` folder. This is because we want the
+  publishing related tools to also have their working directories
+  under `target`. The name `target` is chosen to follow Maven
+  conventions. OPTIONAL
+
+* Update `build-site` to use `target/site` as the target directory for
+  the baked site.  This will also be the directory with the working
+  area for the `gh-pages` branch.
+
+* Update `build-site` to use a configured version of Yawg. This
+  involves downloading and installing it. The Yawg installation should
+  be placed under `target/tools`.
+
+* Created new tool `devtools/bin/build-travisci-publish-site` To
+  perform the actions specific to Travis CI. This new
+  `build-travisci-publish-site`tool will in turn call `build-site` to
+  perform most of the work.
+
+
+
+
+
+Tools:
+
+`devtools/bin/build-site` -- Bakes the site and uploads it to the
+`gh-pages` branch of the project Github Git repository.
+

--- a/doc/content/Download/index.adoc
+++ b/doc/content/Download/index.adoc
@@ -13,7 +13,7 @@ https://github.com/jorgefranconunes/yawg/releases/download/v0.9.4/yawg-0.9.4.tar
 
 * https://github.com/jorgefranconunes/yawg/releases[Older releases]
 
-See the link:../Documentation/UserGuide/index.html[Yawg user guide]
+See the link:../Documentation/UserGuide/UserGuide.html[Yawg user guide]
 for instruction on installing and running Yawg.
 
 

--- a/modules/acceptance/src/test/java/com/varmateo/yawg/atests/BakerRunner.java
+++ b/modules/acceptance/src/test/java/com/varmateo/yawg/atests/BakerRunner.java
@@ -152,6 +152,18 @@ public final class BakerRunner {
         }
 
 
+        /**
+         *
+         */
+        public BakerRunnerResult run() {
+
+            BakerRunner baker = new BakerRunner(this);
+            BakerRunnerResult result = baker.run();
+
+            return result;
+        }
+
+
     }
 
 

--- a/modules/acceptance/src/test/java/com/varmateo/yawg/atests/CliOptionSourceIT.java
+++ b/modules/acceptance/src/test/java/com/varmateo/yawg/atests/CliOptionSourceIT.java
@@ -34,11 +34,10 @@ public final class CliOptionSourceIT {
             throws IOException {
 
         Path sourcePath = TestUtils.getTmpDir(CliOptionSourceIT.class);
-        BakerRunner baker =
+        BakerRunnerResult bakerResult =
                 BakerRunner.builder()
                 .addSourcePath(sourcePath)
-                .build();
-        BakerRunnerResult bakerResult = baker.run();
+                .run();
 
         assertThat(bakerResult)
                 .hasExitStatusFailure()
@@ -56,12 +55,11 @@ public final class CliOptionSourceIT {
 
         Path sourcePath = Paths.get("this-directory-does-not-exist-for-sure");
         Path targetPath = TestUtils.getTmpDir(CliOptionSourceIT.class);
-        BakerRunner baker =
+        BakerRunnerResult bakerResult =
                 BakerRunner.builder()
                 .addSourcePath(sourcePath)
                 .addTargetPath(targetPath)
-                .build();
-        BakerRunnerResult bakerResult = baker.run();
+                .run();
 
         assertThat(bakerResult)
                 .hasExitStatusFailure()

--- a/modules/acceptance/src/test/java/com/varmateo/yawg/atests/CliOptionsIT.java
+++ b/modules/acceptance/src/test/java/com/varmateo/yawg/atests/CliOptionsIT.java
@@ -28,8 +28,7 @@ public final class CliOptionsIT {
     @Test
     public void noArgs() {
 
-        BakerRunner baker = BakerRunner.empty();
-        BakerRunnerResult bakerResult = baker.run();
+        BakerRunnerResult bakerResult = BakerRunner.builder().run();
 
         assertThat(bakerResult)
                 .hasExitStatusSuccess()
@@ -44,11 +43,10 @@ public final class CliOptionsIT {
     @Test
     public void unknownOption() {
 
-        BakerRunner baker =
+        BakerRunnerResult bakerResult =
                 BakerRunner.builder()
                 .addArgs("--this-is-an-unknown-option")
-                .build();
-        BakerRunnerResult bakerResult = baker.run();
+                .run();
 
         assertThat(bakerResult)
                 .hasExitStatusFailure()
@@ -73,11 +71,10 @@ public final class CliOptionsIT {
      */
     private void helpOptionTest(final String option) {
 
-        BakerRunner baker =
+        BakerRunnerResult bakerResult =
                 BakerRunner.builder()
                 .addArg(option)
-                .build();
-        BakerRunnerResult bakerResult = baker.run();
+                .run();
 
         assertThat(bakerResult)
                 .hasExitStatusSuccess()


### PR DESCRIPTION
The `build-site` tool now places the bake result under `target/site`.
This will make it simpler for comming changes in the auto-publishing
process of the Yawg web site to have all bake related artifacts under
one single directory.